### PR TITLE
fix: Fixed typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,7 @@ The new queries uses the same values for fetching properties but gives an eaiser
 
 ### Features
 
-* Added Cors options to the startup extention ([0c087d7](https://github.com/nikcio/Nikcio.UHeadless/commit/0c087d7fcbf9c5bba45fdec6563611f205c7dd73))
+* Added Cors options to the startup extension ([0c087d7](https://github.com/nikcio/Nikcio.UHeadless/commit/0c087d7fcbf9c5bba45fdec6563611f205c7dd73))
 
 
 ### Bug Fixes
@@ -110,7 +110,7 @@ The new queries uses the same values for fetching properties but gives an eaiser
 
 ### Features
 
-* Added automapper extention method ([bef3476](https://github.com/nikcio/Nikcio.UHeadless/commit/bef34764f22bce9579d6a96439cad39e83b8240d))
+* Added automapper extension method ([bef3476](https://github.com/nikcio/Nikcio.UHeadless/commit/bef34764f22bce9579d6a96439cad39e83b8240d))
 * Added depencency reflector factory ([db8236b](https://github.com/nikcio/Nikcio.UHeadless/commit/db8236b498692367b5a0984cca9b969e9952bbe6))
 * Block list & Nested content can now use any type ([a4585d0](https://github.com/nikcio/Nikcio.UHeadless/commit/a4585d0a382803d2e39153f2e361001458dee7d3))
 
@@ -132,5 +132,5 @@ The new queries uses the same values for fetching properties but gives an eaiser
 * Added standard-version ([48be288](https://github.com/nikcio/Nikcio.Umbraco.Headless/commit/48be2889f41d0ada781292486a05daef7aaf4ef7))
 * Added the abillity to fetch properties ([d5d83d8](https://github.com/nikcio/Nikcio.Umbraco.Headless/commit/d5d83d8e8411973ddf7209826007cab8f433da7d))
 * Content fetching 1.0 ([eb8177f](https://github.com/nikcio/Nikcio.Umbraco.Headless/commit/eb8177f7291cb22b09d583407343b10d72f2032a))
-* Created extentions for startup ([76290a0](https://github.com/nikcio/Nikcio.Umbraco.Headless/commit/76290a0dca7b2f6295accc0d36272369fbef302b))
+* Created extensions for startup ([76290a0](https://github.com/nikcio/Nikcio.Umbraco.Headless/commit/76290a0dca7b2f6295accc0d36272369fbef302b))
 * Renamed project ([bd62b60](https://github.com/nikcio/Nikcio.Umbraco.Headless/commit/bd62b6062e7e4f5fad0d0222489808c74f71c3a9))

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To get started, add the following to your `Startup.cs`.
 ## Setup
 
 ```CSharp
-using Nikcio.UHeadless.Extentions;
+using Nikcio.UHeadless.Extensions;
 
 public void ConfigureServices(IServiceCollection services)
         {

--- a/src/Nikcio.UHeadless/Extensions/UHeadlessAutomapperExtensions.cs
+++ b/src/Nikcio.UHeadless/Extensions/UHeadlessAutomapperExtensions.cs
@@ -2,12 +2,12 @@
 using System.Collections.Generic;
 using System.Reflection;
 
-namespace Nikcio.UHeadless.Extentions
+namespace Nikcio.UHeadless.Extensions
 {
     /// <summary>
-    /// All UHeadless extentions that involve the Automapper package
+    /// All UHeadless extensions that involve the Automapper package
     /// </summary>
-    public static class UHeadlessAutomapperExtentions
+    public static class UHeadlessAutomapperExtensions
     {
         /// <summary>
         /// Adds Automapper with a reference to the UHeadless assembly
@@ -22,7 +22,7 @@ namespace Nikcio.UHeadless.Extentions
                 automapperAssemblies = new List<Assembly>();
             }
 
-            automapperAssemblies.Add(typeof(UHeadlessExtentions).Assembly);
+            automapperAssemblies.Add(typeof(UHeadlessExtensions).Assembly);
 
             services
                 .AddAutoMapper(automapperAssemblies);

--- a/src/Nikcio.UHeadless/Extensions/UHeadlessExtensions.cs
+++ b/src/Nikcio.UHeadless/Extensions/UHeadlessExtensions.cs
@@ -2,10 +2,10 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Nikcio.UHeadless.Options;
-using Nikcio.UHeadless.Reflection.Extentions;
-using Nikcio.UHeadless.UmbracoContent.Content.Extentions;
+using Nikcio.UHeadless.Reflection.Extensions;
+using Nikcio.UHeadless.UmbracoContent.Content.Extensions;
 using Nikcio.UHeadless.UmbracoContent.Content.Queries;
-using Nikcio.UHeadless.UmbracoContent.Properties.Extentions;
+using Nikcio.UHeadless.UmbracoContent.Properties.Extensions;
 using Nikcio.UHeadless.UmbracoContent.Properties.Maps;
 using Nikcio.UHeadless.UmbracoContent.Properties.Queries;
 using System;
@@ -13,12 +13,12 @@ using System.Collections.Generic;
 using System.Reflection;
 using Umbraco.Cms.Core.DependencyInjection;
 
-namespace Nikcio.UHeadless.Extentions
+namespace Nikcio.UHeadless.Extensions
 {
     /// <summary>
-    /// The default UHeadless extentions used for the default setup
+    /// The default UHeadless extensions used for the default setup
     /// </summary>
-    public static class UHeadlessExtentions
+    public static class UHeadlessExtensions
     {
         /// <summary>
         /// Adds all services the UHeadless package needs
@@ -34,8 +34,8 @@ namespace Nikcio.UHeadless.Extentions
                                                    List<Action<IPropertyMap>> customPropertyMappings = null,
                                                    bool throwOnSchemaError = false,
                                                    TracingOptions tracingOptions = null,
-                                                   bool useSecuity = false,
-                                                   List<Func<IRequestExecutorBuilder, IRequestExecutorBuilder>> graphQLExtentions = null)
+                                                   bool useSecurity = false,
+                                                   List<Func<IRequestExecutorBuilder, IRequestExecutorBuilder>> graphQLExtensions = null)
         {
             builder.Services.AddUHeadlessAutomapper(automapperAssemblies);
 
@@ -44,9 +44,9 @@ namespace Nikcio.UHeadless.Extentions
                 .AddContentServices()
                 .AddPropertyServices(customPropertyMappings);
 
-            if (graphQLExtentions == null)
+            if (graphQLExtensions == null)
             {
-                graphQLExtentions = new List<Func<IRequestExecutorBuilder, IRequestExecutorBuilder>>
+                graphQLExtensions = new List<Func<IRequestExecutorBuilder, IRequestExecutorBuilder>>
                 { (builder) =>
                     builder
                         .AddTypeExtension<ContentQuery>()
@@ -56,7 +56,7 @@ namespace Nikcio.UHeadless.Extentions
 
             builder.Services
                 .AddGraphQLServer()
-                .AddUHeadlessGraphQL(useSecuity, throwOnSchemaError, graphQLExtentions)
+                .AddUHeadlessGraphQL(useSecurity, throwOnSchemaError, graphQLExtensions)
                 .AddTracing(tracingOptions);
 
             return builder;

--- a/src/Nikcio.UHeadless/Extensions/UHeadlessGraphQLExtensions.cs
+++ b/src/Nikcio.UHeadless/Extensions/UHeadlessGraphQLExtensions.cs
@@ -9,12 +9,12 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Nikcio.UHeadless.Extentions
+namespace Nikcio.UHeadless.Extensions
 {
     /// <summary>
-    /// The UHeadless extentions for GraphQL functionallity
+    /// The UHeadless extensions for GraphQL functionallity
     /// </summary>
-    public static class UHeadlessGraphQLExtentions
+    public static class UHeadlessGraphQLExtensions
     {
         /// <summary>
         /// Adds Apollo tracing if the tracingOptions is set
@@ -38,7 +38,7 @@ namespace Nikcio.UHeadless.Extentions
         /// <param name="requestExecutorBuilder"></param>
         /// <param name="throwOnSchemaError">Should the schema builder throw an exception when a schema error occurs. (true = yes, false = no)</param>
         /// <returns></returns>
-        public static IRequestExecutorBuilder AddUHeadlessGraphQL(this IRequestExecutorBuilder requestExecutorBuilder, bool useSecuity, bool throwOnSchemaError = false, List<Func<IRequestExecutorBuilder, IRequestExecutorBuilder>> graphQLExtentions = null)
+        public static IRequestExecutorBuilder AddUHeadlessGraphQL(this IRequestExecutorBuilder requestExecutorBuilder, bool useSecurity, bool throwOnSchemaError = false, List<Func<IRequestExecutorBuilder, IRequestExecutorBuilder>> graphQLExtensions = null)
         {
             requestExecutorBuilder
                 .InitializeOnStartup()
@@ -47,14 +47,14 @@ namespace Nikcio.UHeadless.Extentions
                 .OnSchemaError(HandleSchemaError(throwOnSchemaError))
                 .AddQueryType<Query>();
 
-            if (useSecuity)
+            if (useSecurity)
             {
                 requestExecutorBuilder.AddAuthorization();
             }
 
-            if (graphQLExtentions != null && graphQLExtentions.Any())
+            if (graphQLExtensions != null && graphQLExtensions.Any())
             {
-                foreach (var extentention in graphQLExtentions)
+                foreach (var extentention in graphQLExtensions)
                 {
                     extentention.Invoke(requestExecutorBuilder);
                 }

--- a/src/Nikcio.UHeadless/Reflection/Extensions/FactoryExtensions.cs
+++ b/src/Nikcio.UHeadless/Reflection/Extensions/FactoryExtensions.cs
@@ -1,12 +1,12 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using Nikcio.UHeadless.Reflection.Factories;
 
-namespace Nikcio.UHeadless.Reflection.Extentions
+namespace Nikcio.UHeadless.Reflection.Extensions
 {
     /// <summary>
-    /// Extentions for the factories
+    /// Extensions for the factories
     /// </summary>
-    public static class FactoryExtentions
+    public static class FactoryExtensions
     {
         /// <summary>
         /// Adds the reflection factories

--- a/src/Nikcio.UHeadless/Reflection/Extensions/ReflectionExtensions.cs
+++ b/src/Nikcio.UHeadless/Reflection/Extensions/ReflectionExtensions.cs
@@ -1,11 +1,11 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 
-namespace Nikcio.UHeadless.Reflection.Extentions
+namespace Nikcio.UHeadless.Reflection.Extensions
 {
     /// <summary>
-    /// Extentions for the Reflections
+    /// Extensions for the Reflections
     /// </summary>
-    public static class ReflectionExtentions
+    public static class ReflectionExtensions
     {
         /// <summary>
         /// Adds all the Reflections services

--- a/src/Nikcio.UHeadless/UmbracoContent/Content/Extensions/ContentExtensions.cs
+++ b/src/Nikcio.UHeadless/UmbracoContent/Content/Extensions/ContentExtensions.cs
@@ -1,11 +1,11 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 
-namespace Nikcio.UHeadless.UmbracoContent.Content.Extentions
+namespace Nikcio.UHeadless.UmbracoContent.Content.Extensions
 {
     /// <summary>
-    /// Content extentions
+    /// Content extensions
     /// </summary>
-    public static class ContentExtentions
+    public static class ContentExtensions
     {
         /// <summary>
         /// Adds all the content services

--- a/src/Nikcio.UHeadless/UmbracoContent/Content/Extensions/RepositoryExtensions.cs
+++ b/src/Nikcio.UHeadless/UmbracoContent/Content/Extensions/RepositoryExtensions.cs
@@ -1,12 +1,12 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using Nikcio.UHeadless.UmbracoContent.Content.Repositories;
 
-namespace Nikcio.UHeadless.UmbracoContent.Content.Extentions
+namespace Nikcio.UHeadless.UmbracoContent.Content.Extensions
 {
     /// <summary>
-    /// Repository extentions
+    /// Repository extensions
     /// </summary>
-    public static class RepositoryExtentions
+    public static class RepositoryExtensions
     {
         /// <summary>
         /// Adds all the content repositories

--- a/src/Nikcio.UHeadless/UmbracoContent/Content/Models/ContentGraphType.cs
+++ b/src/Nikcio.UHeadless/UmbracoContent/Content/Models/ContentGraphType.cs
@@ -56,7 +56,7 @@ namespace Nikcio.UHeadless.UmbracoContent.Content.Models
         public string Url => Content.Url();
 
         [GraphQLDescription("Gets the absolute url of the content item.")]
-        public string AbosulteUrl => Content.Url(Culture, UrlMode.Absolute);
+        public string AbsoluteUrl => Content.Url(Culture, UrlMode.Absolute);
 
         [GraphQLDescription("Gets the name of the content item for the current culture.")]
         public string Name => Content.Name;

--- a/src/Nikcio.UHeadless/UmbracoContent/Properties/EditorsValues/ContentPicker/ContentPickerItemGraphType.cs
+++ b/src/Nikcio.UHeadless/UmbracoContent/Properties/EditorsValues/ContentPicker/ContentPickerItemGraphType.cs
@@ -14,8 +14,8 @@ namespace Nikcio.UHeadless.UmbracoContent.Properties.EditorsValues.ContentPicker
         [GraphQLDescription("Gets the url of a content item.")]
         public string Url => Content.Url();
 
-        [GraphQLDescription("Gets the abosulte url of a content item.")]
-        public string AbosulteUrl => Content.Url(mode: UrlMode.Absolute);
+        [GraphQLDescription("Gets the absolute url of a content item.")]
+        public string AbsoluteUrl => Content.Url(mode: UrlMode.Absolute);
 
         [GraphQLDescription("Gets the name of a content item.")]
         public string Name => Content.Name;

--- a/src/Nikcio.UHeadless/UmbracoContent/Properties/Extensions/FactoryExtensions.cs
+++ b/src/Nikcio.UHeadless/UmbracoContent/Properties/Extensions/FactoryExtensions.cs
@@ -1,12 +1,12 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using Nikcio.UHeadless.UmbracoContent.Properties.Factories;
 
-namespace Nikcio.UHeadless.UmbracoContent.Properties.Extentions
+namespace Nikcio.UHeadless.UmbracoContent.Properties.Extensions
 {
     /// <summary>
-    /// Factory extentions
+    /// Factory extensions
     /// </summary>
-    public static class FactoryExtentions
+    public static class FactoryExtensions
     {
         /// <summary>
         /// Adds all the property factories

--- a/src/Nikcio.UHeadless/UmbracoContent/Properties/Extensions/MapExtensions.cs
+++ b/src/Nikcio.UHeadless/UmbracoContent/Properties/Extensions/MapExtensions.cs
@@ -3,12 +3,12 @@ using Nikcio.UHeadless.UmbracoContent.Properties.Maps;
 using System;
 using System.Collections.Generic;
 
-namespace Nikcio.UHeadless.UmbracoContent.Properties.Extentions
+namespace Nikcio.UHeadless.UmbracoContent.Properties.Extensions
 {
     /// <summary>
-    /// Map extentions
+    /// Map extensions
     /// </summary>
-    public static class MapExtentions
+    public static class MapExtensions
     {
         /// <summary>
         /// Adds the property maps

--- a/src/Nikcio.UHeadless/UmbracoContent/Properties/Extensions/PropertyExtensions.cs
+++ b/src/Nikcio.UHeadless/UmbracoContent/Properties/Extensions/PropertyExtensions.cs
@@ -3,12 +3,12 @@ using Nikcio.UHeadless.UmbracoContent.Properties.Maps;
 using System;
 using System.Collections.Generic;
 
-namespace Nikcio.UHeadless.UmbracoContent.Properties.Extentions
+namespace Nikcio.UHeadless.UmbracoContent.Properties.Extensions
 {
     /// <summary>
-    /// Property extentions
+    /// Property extensions
     /// </summary>
-    public static class PropertyExtentions
+    public static class PropertyExtensions
     {
         /// <summary>
         /// Adds all the property services

--- a/src/Nikcio.UHeadless/UmbracoContent/Properties/Extensions/RepositoryExtensions.cs
+++ b/src/Nikcio.UHeadless/UmbracoContent/Properties/Extensions/RepositoryExtensions.cs
@@ -1,12 +1,12 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using Nikcio.UHeadless.UmbracoContent.Properties.Repositories;
 
-namespace Nikcio.UHeadless.UmbracoContent.Properties.Extentions
+namespace Nikcio.UHeadless.UmbracoContent.Properties.Extensions
 {
     /// <summary>
-    /// Repository extentions
+    /// Repository extensions
     /// </summary>
-    public static class RepositoryExtentions
+    public static class RepositoryExtensions
     {
         /// <summary>
         /// Adds all property reposiotries

--- a/src/TestProject/Startup.cs
+++ b/src/TestProject/Startup.cs
@@ -4,9 +4,9 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Nikcio.ApiAuthentication.Extentions;
-using Nikcio.ApiAuthentication.Extentions.Models;
-using Nikcio.UHeadless.Extentions;
+using Nikcio.ApiAuthentication.Extensions;
+using Nikcio.ApiAuthentication.Extensions.Models;
+using Nikcio.UHeadless.Extensions;
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Extensions;
 
@@ -45,7 +45,7 @@ namespace TestProject
                 .AddBackOffice()
                 .AddWebsite()
                 .AddComposers()
-                .AddUHeadless(useSecuity: true)
+                .AddUHeadless(useSecurity: true)
                 .Build();
 
             services.AddNikcioApiAuthentication(_config, new ApiAuthenticationConfigurationSettings


### PR DESCRIPTION
`extention` > `extension`
`abosulte` > `absolute`
`useSecuity` > `useSecurity`