### PR TITLE
Support query for HTML output from MarkdownEditor

### DIFF
--- a/docs/v3/querying/properties.md
+++ b/docs/v3/querying/properties.md
@@ -76,6 +76,7 @@ query {
                  }
                  ...on BasicRichText {
                    text: value
+                   sourceValue
                  }
                  ...on BasicMediaPicker {
                    mediaItems {
@@ -94,5 +95,7 @@ query {
 ```
 
 Here the `BasicRichText` value property conflicts with the `BasicPropertyValue` value property so it's renamed to `text`.
+
+The raw output from the TinyMCE or Markdown Editor is returned as `sourceValue`.
 
 For further information on aliases in GraphQL see: https://graphql.org/learn/queries/

--- a/src/Nikcio.UHeadless.Base/Basics/EditorsValues/RichTextEditor/Models/BasicRichText.cs
+++ b/src/Nikcio.UHeadless.Base/Basics/EditorsValues/RichTextEditor/Models/BasicRichText.cs
@@ -12,10 +12,16 @@ namespace Nikcio.UHeadless.Basics.Properties.EditorsValues.RichTextEditor.Models
 public class BasicRichText : PropertyValue
 {
     /// <summary>
-    /// Gets the value of the rich text editor
+    /// Gets the HTML value of the rich text editor or markdown editor
     /// </summary>
-    [GraphQLDescription("Gets the value of the rich text editor.")]
+    [GraphQLDescription("Gets the HTML value of the rich text editor or markdown editor.")]
     public virtual string? Value { get; set; }
+
+    /// <summary>
+    /// Gets the original value of the rich text editor or markdown editor
+    /// </summary>
+    [GraphQLDescription("Gets the original value of the rich text editor or markdown editor.")]
+    public virtual string? SourceValue { get; set; }
 
     /// <inheritdoc/>
     public BasicRichText(CreatePropertyValue createPropertyValue) : base(createPropertyValue)
@@ -26,5 +32,6 @@ public class BasicRichText : PropertyValue
             return;
         }
         Value = ((IHtmlEncodedString) propertyValue)?.ToHtmlString();
+        SourceValue = createPropertyValue.Property.GetSourceValue(createPropertyValue.Culture)?.ToString();
     }
 }

--- a/src/Nikcio.UHeadless.Base/Basics/Maps/Extensions/PropertyMapExtensions.cs
+++ b/src/Nikcio.UHeadless.Base/Basics/Maps/Extensions/PropertyMapExtensions.cs
@@ -30,6 +30,7 @@ public static class PropertyMapExtensions
         propertyMap.AddEditorMapping<BasicBlockListModel>(Constants.PropertyEditors.Aliases.BlockList);
         propertyMap.AddEditorMapping<BasicNestedContent>(Constants.PropertyEditors.Aliases.NestedContent);
         propertyMap.AddEditorMapping<BasicRichText>(Constants.PropertyEditors.Aliases.TinyMce);
+        propertyMap.AddEditorMapping<BasicRichText>(Constants.PropertyEditors.Aliases.MarkdownEditor);
         propertyMap.AddEditorMapping<BasicMemberPicker>(Constants.PropertyEditors.Aliases.MemberPicker);
         propertyMap.AddEditorMapping<BasicContentPicker>(Constants.PropertyEditors.Aliases.ContentPicker);
         propertyMap.AddEditorMapping<BasicMultiUrlPicker>(Constants.PropertyEditors.Aliases.MultiUrlPicker);


### PR DESCRIPTION
Also supports output of original value from MarkdownEditor and TinyMCE, and documents this feature.

Refer issue #109.