### PR TITLE
Fix empty medial url on multi lingual site. culture: null

### DIFF
--- a/src/Nikcio.UHeadless.Base/Basics/EditorsValues/MediaPicker/Models/BasicMediaPickerItem.cs
+++ b/src/Nikcio.UHeadless.Base/Basics/EditorsValues/MediaPicker/Models/BasicMediaPickerItem.cs
@@ -27,7 +27,8 @@ public class BasicMediaPickerItem : MediaPickerItem
     /// <inheritdoc/>
     public BasicMediaPickerItem(CreateMediaPickerItem createMediaPickerItem) : base(createMediaPickerItem)
     {
-        Url = createMediaPickerItem.PublishedContent.MediaUrl(culture: createMediaPickerItem.Culture, mode: UrlMode.Absolute);
+        // As of version 11.3.1, Umbraco does not support multilingual media type so culture has to be null.
+        Url = createMediaPickerItem.PublishedContent.MediaUrl(culture: null, mode: UrlMode.Absolute);
         Id = createMediaPickerItem.PublishedContent.Id;
     }
 }


### PR DESCRIPTION
As of version 11.3.1, Umbraco does not support multilingual media type so culture has to be null here. Otherwise, we will get `url: ""` on multilingual sites.
