### PR TITLE
refactor!: Conform namespaces after folder structure

### DIFF
--- a/src/Examples/Docs/Content/CustomBasicContent.cs
+++ b/src/Examples/Docs/Content/CustomBasicContent.cs
@@ -1,5 +1,5 @@
-﻿using Nikcio.UHeadless.Base.Properties.Factories;
-using Nikcio.UHeadless.Basics.Properties.Models;
+﻿using Nikcio.UHeadless.Base.Basics.Models;
+using Nikcio.UHeadless.Base.Properties.Factories;
 using Nikcio.UHeadless.Content.Basics.Models;
 using Nikcio.UHeadless.Content.Commands;
 using Nikcio.UHeadless.Content.Factories;

--- a/src/Examples/Docs/PropertyValues/CustomBlockListModel.cs
+++ b/src/Examples/Docs/PropertyValues/CustomBlockListModel.cs
@@ -1,6 +1,6 @@
-﻿using Nikcio.UHeadless.Base.Properties.Commands;
-using Nikcio.UHeadless.Basics.Properties.EditorsValues.BlockList.Models;
-using Nikcio.UHeadless.Basics.Properties.Models;
+﻿using Nikcio.UHeadless.Base.Basics.EditorsValues.BlockList.Models;
+using Nikcio.UHeadless.Base.Basics.Models;
+using Nikcio.UHeadless.Base.Properties.Commands;
 using Nikcio.UHeadless.Core.Reflection.Factories;
 
 namespace Examples.Docs.PropertyValues;

--- a/src/Examples/Docs/PropertyValues/CustomMediaPicker.cs
+++ b/src/Examples/Docs/PropertyValues/CustomMediaPicker.cs
@@ -1,5 +1,5 @@
-﻿using Nikcio.UHeadless.Base.Properties.Commands;
-using Nikcio.UHeadless.Basics.Properties.EditorsValues.MediaPicker.Models;
+﻿using Nikcio.UHeadless.Base.Basics.EditorsValues.MediaPicker.Models;
+using Nikcio.UHeadless.Base.Properties.Commands;
 using Nikcio.UHeadless.Core.Reflection.Factories;
 
 namespace Examples.Docs.PropertyValues;

--- a/src/Examples/Docs/PropertyValues/CustomRichText.cs
+++ b/src/Examples/Docs/PropertyValues/CustomRichText.cs
@@ -1,5 +1,5 @@
-﻿using Nikcio.UHeadless.Base.Properties.Commands;
-using Nikcio.UHeadless.Basics.Properties.EditorsValues.RichTextEditor.Models;
+﻿using Nikcio.UHeadless.Base.Basics.EditorsValues.RichTextEditor.Models;
+using Nikcio.UHeadless.Base.Properties.Commands;
 
 namespace Examples.Docs.PropertyValues;
 

--- a/src/Nikcio.UHeadless.Base.Tests/Reflection/DependencyReflectorFactoryTests.cs
+++ b/src/Nikcio.UHeadless.Base.Tests/Reflection/DependencyReflectorFactoryTests.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.Extensions.Logging;
 using Nikcio.UHeadless.Core.Reflection.Factories;
 
-namespace Nikcio.UHeadless.Base.Tests.Reflection.Factories;
+namespace Nikcio.UHeadless.Base.Tests.Reflection;
 
 [TestFixture]
 [Parallelizable(ParallelScope.All)]

--- a/src/Nikcio.UHeadless.Base/Base/Basics/EditorsValues/BlockGrid/Models/BasicBlockGridItem.cs
+++ b/src/Nikcio.UHeadless.Base/Base/Basics/EditorsValues/BlockGrid/Models/BasicBlockGridItem.cs
@@ -1,8 +1,8 @@
-﻿using Nikcio.UHeadless.Base.Properties.EditorsValues.BlockGrid.Commands;
+﻿using Nikcio.UHeadless.Base.Basics.Models;
+using Nikcio.UHeadless.Base.Properties.EditorsValues.BlockGrid.Commands;
 using Nikcio.UHeadless.Base.Properties.EditorsValues.BlockGrid.Models;
 using Nikcio.UHeadless.Base.Properties.Factories;
 using Nikcio.UHeadless.Base.Properties.Models;
-using Nikcio.UHeadless.Basics.Properties.Models;
 using Nikcio.UHeadless.Core.Reflection.Factories;
 
 namespace Nikcio.UHeadless.Base.Basics.EditorsValues.BlockGrid.Models;

--- a/src/Nikcio.UHeadless.Base/Base/Basics/EditorsValues/BlockList/Models/BasicBlockListItem.cs
+++ b/src/Nikcio.UHeadless.Base/Base/Basics/EditorsValues/BlockList/Models/BasicBlockListItem.cs
@@ -1,10 +1,10 @@
-﻿using Nikcio.UHeadless.Base.Properties.EditorsValues.BlockList.Commands;
+﻿using Nikcio.UHeadless.Base.Basics.Models;
+using Nikcio.UHeadless.Base.Properties.EditorsValues.BlockList.Commands;
 using Nikcio.UHeadless.Base.Properties.EditorsValues.BlockList.Models;
 using Nikcio.UHeadless.Base.Properties.Factories;
 using Nikcio.UHeadless.Base.Properties.Models;
-using Nikcio.UHeadless.Basics.Properties.Models;
 
-namespace Nikcio.UHeadless.Basics.Properties.EditorsValues.BlockList.Models;
+namespace Nikcio.UHeadless.Base.Basics.EditorsValues.BlockList.Models;
 
 /// <inheritdoc/>
 [GraphQLDescription("Represents a block list item.")]

--- a/src/Nikcio.UHeadless.Base/Base/Basics/EditorsValues/BlockList/Models/BasicBlockListModel.cs
+++ b/src/Nikcio.UHeadless.Base/Base/Basics/EditorsValues/BlockList/Models/BasicBlockListModel.cs
@@ -5,7 +5,7 @@ using Nikcio.UHeadless.Base.Properties.Models;
 using Nikcio.UHeadless.Core.Reflection.Factories;
 using Umbraco.Extensions;
 
-namespace Nikcio.UHeadless.Basics.Properties.EditorsValues.BlockList.Models;
+namespace Nikcio.UHeadless.Base.Basics.EditorsValues.BlockList.Models;
 
 /// <summary>
 /// Represents a block list model

--- a/src/Nikcio.UHeadless.Base/Base/Basics/EditorsValues/ContentPicker/Models/BasicContentPicker.cs
+++ b/src/Nikcio.UHeadless.Base/Base/Basics/EditorsValues/ContentPicker/Models/BasicContentPicker.cs
@@ -6,7 +6,7 @@ using Nikcio.UHeadless.Core.Reflection.Factories;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Extensions;
 
-namespace Nikcio.UHeadless.Basics.Properties.EditorsValues.ContentPicker.Models;
+namespace Nikcio.UHeadless.Base.Basics.EditorsValues.ContentPicker.Models;
 
 /// <summary>
 /// Represents a content picker value

--- a/src/Nikcio.UHeadless.Base/Base/Basics/EditorsValues/ContentPicker/Models/BasicContentPickerItem.cs
+++ b/src/Nikcio.UHeadless.Base/Base/Basics/EditorsValues/ContentPicker/Models/BasicContentPickerItem.cs
@@ -3,7 +3,7 @@ using Nikcio.UHeadless.Base.Properties.EditorsValues.ContentPicker.Models;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Extensions;
 
-namespace Nikcio.UHeadless.Basics.Properties.EditorsValues.ContentPicker.Models;
+namespace Nikcio.UHeadless.Base.Basics.EditorsValues.ContentPicker.Models;
 
 /// <summary>
 /// Represents a content picker item

--- a/src/Nikcio.UHeadless.Base/Base/Basics/EditorsValues/DateTimePicker/Models/BasicDateTimePicker.cs
+++ b/src/Nikcio.UHeadless.Base/Base/Basics/EditorsValues/DateTimePicker/Models/BasicDateTimePicker.cs
@@ -2,7 +2,7 @@
 using Nikcio.UHeadless.Base.Properties.Models;
 using Umbraco.Extensions;
 
-namespace Nikcio.UHeadless.Basics.Properties.EditorsValues.DateTimePicker.Models;
+namespace Nikcio.UHeadless.Base.Basics.EditorsValues.DateTimePicker.Models;
 
 /// <summary>
 /// Represents a date time property value

--- a/src/Nikcio.UHeadless.Base/Base/Basics/EditorsValues/Fallback/Models/BasicPropertyValue.cs
+++ b/src/Nikcio.UHeadless.Base/Base/Basics/EditorsValues/Fallback/Models/BasicPropertyValue.cs
@@ -2,7 +2,7 @@
 using Nikcio.UHeadless.Base.Properties.Models;
 using Umbraco.Extensions;
 
-namespace Nikcio.UHeadless.Basics.Properties.EditorsValues.Fallback.Models;
+namespace Nikcio.UHeadless.Base.Basics.EditorsValues.Fallback.Models;
 
 /// <summary>
 /// Represents a basic property value

--- a/src/Nikcio.UHeadless.Base/Base/Basics/EditorsValues/MediaPicker/Models/BasicMediaPicker.cs
+++ b/src/Nikcio.UHeadless.Base/Base/Basics/EditorsValues/MediaPicker/Models/BasicMediaPicker.cs
@@ -6,7 +6,7 @@ using Nikcio.UHeadless.Core.Reflection.Factories;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Extensions;
 
-namespace Nikcio.UHeadless.Basics.Properties.EditorsValues.MediaPicker.Models;
+namespace Nikcio.UHeadless.Base.Basics.EditorsValues.MediaPicker.Models;
 
 /// <summary>
 /// Represents a media picker item

--- a/src/Nikcio.UHeadless.Base/Base/Basics/EditorsValues/MediaPicker/Models/BasicMediaPickerItem.cs
+++ b/src/Nikcio.UHeadless.Base/Base/Basics/EditorsValues/MediaPicker/Models/BasicMediaPickerItem.cs
@@ -3,7 +3,7 @@ using Nikcio.UHeadless.Base.Properties.EditorsValues.MediaPicker.Models;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Extensions;
 
-namespace Nikcio.UHeadless.Basics.Properties.EditorsValues.MediaPicker.Models;
+namespace Nikcio.UHeadless.Base.Basics.EditorsValues.MediaPicker.Models;
 
 /// <summary>
 /// Represents a media item

--- a/src/Nikcio.UHeadless.Base/Base/Basics/EditorsValues/MemberPicker/Models/BasicMemberPicker.cs
+++ b/src/Nikcio.UHeadless.Base/Base/Basics/EditorsValues/MemberPicker/Models/BasicMemberPicker.cs
@@ -6,7 +6,7 @@ using Nikcio.UHeadless.Core.Reflection.Factories;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Extensions;
 
-namespace Nikcio.UHeadless.Basics.Properties.EditorsValues.MemberPicker.Models;
+namespace Nikcio.UHeadless.Base.Basics.EditorsValues.MemberPicker.Models;
 
 /// <summary>
 /// Represents a member picker

--- a/src/Nikcio.UHeadless.Base/Base/Basics/EditorsValues/MemberPicker/Models/BasicMemberPickerItem.cs
+++ b/src/Nikcio.UHeadless.Base/Base/Basics/EditorsValues/MemberPicker/Models/BasicMemberPickerItem.cs
@@ -1,10 +1,10 @@
-﻿using Nikcio.UHeadless.Base.Properties.EditorsValues.MemberPicker.Commands;
+﻿using Nikcio.UHeadless.Base.Basics.Models;
+using Nikcio.UHeadless.Base.Properties.EditorsValues.MemberPicker.Commands;
 using Nikcio.UHeadless.Base.Properties.EditorsValues.MemberPicker.Models;
 using Nikcio.UHeadless.Base.Properties.Factories;
 using Nikcio.UHeadless.Base.Properties.Models;
-using Nikcio.UHeadless.Basics.Properties.Models;
 
-namespace Nikcio.UHeadless.Basics.Properties.EditorsValues.MemberPicker.Models;
+namespace Nikcio.UHeadless.Base.Basics.EditorsValues.MemberPicker.Models;
 
 /// <inheritdoc/>
 [GraphQLDescription("Represents a member item.")]

--- a/src/Nikcio.UHeadless.Base/Base/Basics/EditorsValues/MultiUrlPicker/Models/BasicMultiUrlPicker.cs
+++ b/src/Nikcio.UHeadless.Base/Base/Basics/EditorsValues/MultiUrlPicker/Models/BasicMultiUrlPicker.cs
@@ -6,7 +6,7 @@ using Nikcio.UHeadless.Core.Reflection.Factories;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Extensions;
 
-namespace Nikcio.UHeadless.Basics.Properties.EditorsValues.MultiUrlPicker.Models;
+namespace Nikcio.UHeadless.Base.Basics.EditorsValues.MultiUrlPicker.Models;
 
 /// <summary>
 /// Represents a multi url picker

--- a/src/Nikcio.UHeadless.Base/Base/Basics/EditorsValues/MultiUrlPicker/Models/BasicMultiUrlPickerItem.cs
+++ b/src/Nikcio.UHeadless.Base/Base/Basics/EditorsValues/MultiUrlPicker/Models/BasicMultiUrlPickerItem.cs
@@ -2,7 +2,7 @@
 using Nikcio.UHeadless.Base.Properties.EditorsValues.MultiUrlPicker.Models;
 using Umbraco.Cms.Core.Models;
 
-namespace Nikcio.UHeadless.Basics.Properties.EditorsValues.MultiUrlPicker.Models;
+namespace Nikcio.UHeadless.Base.Basics.EditorsValues.MultiUrlPicker.Models;
 
 /// <summary>
 /// Represents a link item

--- a/src/Nikcio.UHeadless.Base/Base/Basics/EditorsValues/NestedContent/Models/BasicNestedContent.cs
+++ b/src/Nikcio.UHeadless.Base/Base/Basics/EditorsValues/NestedContent/Models/BasicNestedContent.cs
@@ -6,7 +6,7 @@ using Nikcio.UHeadless.Core.Reflection.Factories;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Extensions;
 
-namespace Nikcio.UHeadless.Basics.Properties.EditorsValues.NestedContent.Models;
+namespace Nikcio.UHeadless.Base.Basics.EditorsValues.NestedContent.Models;
 
 /// <summary>
 /// Represents nested content

--- a/src/Nikcio.UHeadless.Base/Base/Basics/EditorsValues/NestedContent/Models/BasicNestedContentElement.cs
+++ b/src/Nikcio.UHeadless.Base/Base/Basics/EditorsValues/NestedContent/Models/BasicNestedContentElement.cs
@@ -1,10 +1,10 @@
-﻿using Nikcio.UHeadless.Base.Properties.EditorsValues.NestedContent.Commands;
+﻿using Nikcio.UHeadless.Base.Basics.Models;
+using Nikcio.UHeadless.Base.Properties.EditorsValues.NestedContent.Commands;
 using Nikcio.UHeadless.Base.Properties.EditorsValues.NestedContent.Models;
 using Nikcio.UHeadless.Base.Properties.Factories;
 using Nikcio.UHeadless.Base.Properties.Models;
-using Nikcio.UHeadless.Basics.Properties.Models;
 
-namespace Nikcio.UHeadless.Basics.Properties.EditorsValues.NestedContent.Models;
+namespace Nikcio.UHeadless.Base.Basics.EditorsValues.NestedContent.Models;
 
 /// <summary>
 /// Represents nested content

--- a/src/Nikcio.UHeadless.Base/Base/Basics/EditorsValues/RichTextEditor/Models/BasicRichText.cs
+++ b/src/Nikcio.UHeadless.Base/Base/Basics/EditorsValues/RichTextEditor/Models/BasicRichText.cs
@@ -3,7 +3,7 @@ using Nikcio.UHeadless.Base.Properties.Models;
 using Umbraco.Cms.Core.Strings;
 using Umbraco.Extensions;
 
-namespace Nikcio.UHeadless.Basics.Properties.EditorsValues.RichTextEditor.Models;
+namespace Nikcio.UHeadless.Base.Basics.EditorsValues.RichTextEditor.Models;
 
 /// <summary>
 /// Represents a rich text editor

--- a/src/Nikcio.UHeadless.Base/Base/Basics/Maps/Extensions/PropertyMapExtensions.cs
+++ b/src/Nikcio.UHeadless.Base/Base/Basics/Maps/Extensions/PropertyMapExtensions.cs
@@ -1,20 +1,19 @@
 ﻿using Nikcio.UHeadless.Base.Basics.EditorsValues.BlockGrid.Models;
+using Nikcio.UHeadless.Base.Basics.EditorsValues.BlockList.Models;
+using Nikcio.UHeadless.Base.Basics.EditorsValues.ContentPicker.Models;
+using Nikcio.UHeadless.Base.Basics.EditorsValues.DateTimePicker.Models;
 using Nikcio.UHeadless.Base.Basics.EditorsValues.Fallback.Models;
 using Nikcio.UHeadless.Base.Basics.EditorsValues.Labels.Models;
+using Nikcio.UHeadless.Base.Basics.EditorsValues.MediaPicker.Models;
+using Nikcio.UHeadless.Base.Basics.EditorsValues.MemberPicker.Models;
+using Nikcio.UHeadless.Base.Basics.EditorsValues.MultiUrlPicker.Models;
+using Nikcio.UHeadless.Base.Basics.EditorsValues.NestedContent.Models;
+using Nikcio.UHeadless.Base.Basics.EditorsValues.RichTextEditor.Models;
 using Nikcio.UHeadless.Base.Properties.Maps;
-using Nikcio.UHeadless.Basics.Properties.EditorsValues.BlockList.Models;
-using Nikcio.UHeadless.Basics.Properties.EditorsValues.ContentPicker.Models;
-using Nikcio.UHeadless.Basics.Properties.EditorsValues.DateTimePicker.Models;
-using Nikcio.UHeadless.Basics.Properties.EditorsValues.Fallback.Models;
-using Nikcio.UHeadless.Basics.Properties.EditorsValues.MediaPicker.Models;
-using Nikcio.UHeadless.Basics.Properties.EditorsValues.MemberPicker.Models;
-using Nikcio.UHeadless.Basics.Properties.EditorsValues.MultiUrlPicker.Models;
-using Nikcio.UHeadless.Basics.Properties.EditorsValues.NestedContent.Models;
-using Nikcio.UHeadless.Basics.Properties.EditorsValues.RichTextEditor.Models;
 using Nikcio.UHeadless.Core.Constants;
 using Umbraco.Cms.Core;
 
-namespace Nikcio.UHeadless.Basics.Properties.Maps.Extensions;
+namespace Nikcio.UHeadless.Base.Basics.Maps.Extensions;
 
 /// <summary>
 /// Extensions

--- a/src/Nikcio.UHeadless.Base/Base/Basics/Models/BasicProperty.cs
+++ b/src/Nikcio.UHeadless.Base/Base/Basics/Models/BasicProperty.cs
@@ -3,7 +3,7 @@ using Nikcio.UHeadless.Base.Properties.Factories;
 using Nikcio.UHeadless.Base.Properties.Models;
 using Umbraco.Cms.Core.Models.PublishedContent;
 
-namespace Nikcio.UHeadless.Basics.Properties.Models;
+namespace Nikcio.UHeadless.Base.Basics.Models;
 
 /// <inheritdoc/>
 [GraphQLDescription("Represents a property.")]

--- a/src/Nikcio.UHeadless.Content/Basics/Models/BasicContent.cs
+++ b/src/Nikcio.UHeadless.Content/Basics/Models/BasicContent.cs
@@ -1,8 +1,8 @@
 ﻿using HotChocolate;
 using HotChocolate.Data;
+using Nikcio.UHeadless.Base.Basics.Models;
 using Nikcio.UHeadless.Base.Properties.Factories;
 using Nikcio.UHeadless.Base.Properties.Models;
-using Nikcio.UHeadless.Basics.Properties.Models;
 using Nikcio.UHeadless.Content.Commands;
 using Nikcio.UHeadless.Content.Factories;
 using Nikcio.UHeadless.Content.Models;

--- a/src/Nikcio.UHeadless.Content/Basics/Queries/AuthContentAllQuery.cs
+++ b/src/Nikcio.UHeadless.Content/Basics/Queries/AuthContentAllQuery.cs
@@ -1,8 +1,8 @@
 using HotChocolate;
 using HotChocolate.Authorization;
 using HotChocolate.Types;
+using Nikcio.UHeadless.Base.Basics.Models;
 using Nikcio.UHeadless.Base.Properties.Models;
-using Nikcio.UHeadless.Basics.Properties.Models;
 using Nikcio.UHeadless.Content.Basics.Models;
 using Nikcio.UHeadless.Content.Queries;
 using Nikcio.UHeadless.Content.Repositories;

--- a/src/Nikcio.UHeadless.Content/Basics/Queries/AuthContentAtRootQuery.cs
+++ b/src/Nikcio.UHeadless.Content/Basics/Queries/AuthContentAtRootQuery.cs
@@ -1,8 +1,8 @@
 using HotChocolate;
 using HotChocolate.Authorization;
 using HotChocolate.Types;
+using Nikcio.UHeadless.Base.Basics.Models;
 using Nikcio.UHeadless.Base.Properties.Models;
-using Nikcio.UHeadless.Basics.Properties.Models;
 using Nikcio.UHeadless.Content.Basics.Models;
 using Nikcio.UHeadless.Content.Queries;
 using Nikcio.UHeadless.Content.Repositories;

--- a/src/Nikcio.UHeadless.Content/Basics/Queries/AuthContentByAbsoluteRouteQuery.cs
+++ b/src/Nikcio.UHeadless.Content/Basics/Queries/AuthContentByAbsoluteRouteQuery.cs
@@ -1,8 +1,8 @@
 using HotChocolate;
 using HotChocolate.Authorization;
 using HotChocolate.Types;
+using Nikcio.UHeadless.Base.Basics.Models;
 using Nikcio.UHeadless.Base.Properties.Models;
-using Nikcio.UHeadless.Basics.Properties.Models;
 using Nikcio.UHeadless.Content.Basics.Models;
 using Nikcio.UHeadless.Content.Enums;
 using Nikcio.UHeadless.Content.Queries;

--- a/src/Nikcio.UHeadless.Content/Basics/Queries/AuthContentByContentTypeQuery.cs
+++ b/src/Nikcio.UHeadless.Content/Basics/Queries/AuthContentByContentTypeQuery.cs
@@ -1,8 +1,8 @@
 using HotChocolate;
 using HotChocolate.Authorization;
 using HotChocolate.Types;
+using Nikcio.UHeadless.Base.Basics.Models;
 using Nikcio.UHeadless.Base.Properties.Models;
-using Nikcio.UHeadless.Basics.Properties.Models;
 using Nikcio.UHeadless.Content.Basics.Models;
 using Nikcio.UHeadless.Content.Queries;
 using Nikcio.UHeadless.Content.Repositories;

--- a/src/Nikcio.UHeadless.Content/Basics/Queries/AuthContentByGuidQuery.cs
+++ b/src/Nikcio.UHeadless.Content/Basics/Queries/AuthContentByGuidQuery.cs
@@ -1,8 +1,8 @@
 using HotChocolate;
 using HotChocolate.Authorization;
 using HotChocolate.Types;
+using Nikcio.UHeadless.Base.Basics.Models;
 using Nikcio.UHeadless.Base.Properties.Models;
-using Nikcio.UHeadless.Basics.Properties.Models;
 using Nikcio.UHeadless.Content.Basics.Models;
 using Nikcio.UHeadless.Content.Queries;
 using Nikcio.UHeadless.Content.Repositories;

--- a/src/Nikcio.UHeadless.Content/Basics/Queries/AuthContentByIdQuery.cs
+++ b/src/Nikcio.UHeadless.Content/Basics/Queries/AuthContentByIdQuery.cs
@@ -1,8 +1,8 @@
 using HotChocolate;
 using HotChocolate.Authorization;
 using HotChocolate.Types;
+using Nikcio.UHeadless.Base.Basics.Models;
 using Nikcio.UHeadless.Base.Properties.Models;
-using Nikcio.UHeadless.Basics.Properties.Models;
 using Nikcio.UHeadless.Content.Basics.Models;
 using Nikcio.UHeadless.Content.Queries;
 using Nikcio.UHeadless.Content.Repositories;

--- a/src/Nikcio.UHeadless.Content/Basics/Queries/AuthContentByTagQuery.cs
+++ b/src/Nikcio.UHeadless.Content/Basics/Queries/AuthContentByTagQuery.cs
@@ -1,8 +1,8 @@
 using HotChocolate;
 using HotChocolate.Authorization;
 using HotChocolate.Types;
+using Nikcio.UHeadless.Base.Basics.Models;
 using Nikcio.UHeadless.Base.Properties.Models;
-using Nikcio.UHeadless.Basics.Properties.Models;
 using Nikcio.UHeadless.Content.Basics.Models;
 using Nikcio.UHeadless.Content.Queries;
 using Nikcio.UHeadless.Content.Repositories;

--- a/src/Nikcio.UHeadless.Content/Basics/Queries/AuthContentDescendantsByAbsoluteRouteQuery.cs
+++ b/src/Nikcio.UHeadless.Content/Basics/Queries/AuthContentDescendantsByAbsoluteRouteQuery.cs
@@ -1,8 +1,8 @@
 using HotChocolate;
 using HotChocolate.Authorization;
 using HotChocolate.Types;
+using Nikcio.UHeadless.Base.Basics.Models;
 using Nikcio.UHeadless.Base.Properties.Models;
-using Nikcio.UHeadless.Basics.Properties.Models;
 using Nikcio.UHeadless.Content.Basics.Models;
 using Nikcio.UHeadless.Content.Enums;
 using Nikcio.UHeadless.Content.Queries;

--- a/src/Nikcio.UHeadless.Content/Basics/Queries/AuthContentDescendantsByContentTypeQuery.cs
+++ b/src/Nikcio.UHeadless.Content/Basics/Queries/AuthContentDescendantsByContentTypeQuery.cs
@@ -1,8 +1,8 @@
 using HotChocolate;
 using HotChocolate.Authorization;
 using HotChocolate.Types;
+using Nikcio.UHeadless.Base.Basics.Models;
 using Nikcio.UHeadless.Base.Properties.Models;
-using Nikcio.UHeadless.Basics.Properties.Models;
 using Nikcio.UHeadless.Content.Basics.Models;
 using Nikcio.UHeadless.Content.Queries;
 using Nikcio.UHeadless.Content.Repositories;

--- a/src/Nikcio.UHeadless.Content/Basics/Queries/AuthContentDescendantsByGuidQuery.cs
+++ b/src/Nikcio.UHeadless.Content/Basics/Queries/AuthContentDescendantsByGuidQuery.cs
@@ -1,8 +1,8 @@
 using HotChocolate;
 using HotChocolate.Authorization;
 using HotChocolate.Types;
+using Nikcio.UHeadless.Base.Basics.Models;
 using Nikcio.UHeadless.Base.Properties.Models;
-using Nikcio.UHeadless.Basics.Properties.Models;
 using Nikcio.UHeadless.Content.Basics.Models;
 using Nikcio.UHeadless.Content.Queries;
 using Nikcio.UHeadless.Content.Repositories;

--- a/src/Nikcio.UHeadless.Content/Basics/Queries/AuthContentDescendantsByIdQuery.cs
+++ b/src/Nikcio.UHeadless.Content/Basics/Queries/AuthContentDescendantsByIdQuery.cs
@@ -1,8 +1,8 @@
 using HotChocolate;
 using HotChocolate.Authorization;
 using HotChocolate.Types;
+using Nikcio.UHeadless.Base.Basics.Models;
 using Nikcio.UHeadless.Base.Properties.Models;
-using Nikcio.UHeadless.Basics.Properties.Models;
 using Nikcio.UHeadless.Content.Basics.Models;
 using Nikcio.UHeadless.Content.Queries;
 using Nikcio.UHeadless.Content.Repositories;

--- a/src/Nikcio.UHeadless.Content/Basics/Queries/BasicContentAllQuery.cs
+++ b/src/Nikcio.UHeadless.Content/Basics/Queries/BasicContentAllQuery.cs
@@ -1,5 +1,5 @@
 using HotChocolate.Types;
-using Nikcio.UHeadless.Basics.Properties.Models;
+using Nikcio.UHeadless.Base.Basics.Models;
 using Nikcio.UHeadless.Content.Basics.Models;
 using Nikcio.UHeadless.Content.Queries;
 using Nikcio.UHeadless.Core.GraphQL.Queries;

--- a/src/Nikcio.UHeadless.Content/Basics/Queries/BasicContentAtRootQuery.cs
+++ b/src/Nikcio.UHeadless.Content/Basics/Queries/BasicContentAtRootQuery.cs
@@ -1,5 +1,5 @@
 using HotChocolate.Types;
-using Nikcio.UHeadless.Basics.Properties.Models;
+using Nikcio.UHeadless.Base.Basics.Models;
 using Nikcio.UHeadless.Content.Basics.Models;
 using Nikcio.UHeadless.Content.Queries;
 using Nikcio.UHeadless.Core.GraphQL.Queries;

--- a/src/Nikcio.UHeadless.Content/Basics/Queries/BasicContentByAbsoluteRouteQuery.cs
+++ b/src/Nikcio.UHeadless.Content/Basics/Queries/BasicContentByAbsoluteRouteQuery.cs
@@ -1,5 +1,5 @@
 using HotChocolate.Types;
-using Nikcio.UHeadless.Basics.Properties.Models;
+using Nikcio.UHeadless.Base.Basics.Models;
 using Nikcio.UHeadless.Content.Basics.Models;
 using Nikcio.UHeadless.Content.Queries;
 using Nikcio.UHeadless.Core.GraphQL.Queries;

--- a/src/Nikcio.UHeadless.Content/Basics/Queries/BasicContentByContentTypeQuery.cs
+++ b/src/Nikcio.UHeadless.Content/Basics/Queries/BasicContentByContentTypeQuery.cs
@@ -1,5 +1,5 @@
 using HotChocolate.Types;
-using Nikcio.UHeadless.Basics.Properties.Models;
+using Nikcio.UHeadless.Base.Basics.Models;
 using Nikcio.UHeadless.Content.Basics.Models;
 using Nikcio.UHeadless.Content.Queries;
 using Nikcio.UHeadless.Core.GraphQL.Queries;

--- a/src/Nikcio.UHeadless.Content/Basics/Queries/BasicContentByGuidQuery.cs
+++ b/src/Nikcio.UHeadless.Content/Basics/Queries/BasicContentByGuidQuery.cs
@@ -1,5 +1,5 @@
 using HotChocolate.Types;
-using Nikcio.UHeadless.Basics.Properties.Models;
+using Nikcio.UHeadless.Base.Basics.Models;
 using Nikcio.UHeadless.Content.Basics.Models;
 using Nikcio.UHeadless.Content.Queries;
 using Nikcio.UHeadless.Core.GraphQL.Queries;

--- a/src/Nikcio.UHeadless.Content/Basics/Queries/BasicContentByIdQuery.cs
+++ b/src/Nikcio.UHeadless.Content/Basics/Queries/BasicContentByIdQuery.cs
@@ -1,5 +1,5 @@
 using HotChocolate.Types;
-using Nikcio.UHeadless.Basics.Properties.Models;
+using Nikcio.UHeadless.Base.Basics.Models;
 using Nikcio.UHeadless.Content.Basics.Models;
 using Nikcio.UHeadless.Content.Queries;
 using Nikcio.UHeadless.Core.GraphQL.Queries;

--- a/src/Nikcio.UHeadless.Content/Basics/Queries/BasicContentByTagQuery.cs
+++ b/src/Nikcio.UHeadless.Content/Basics/Queries/BasicContentByTagQuery.cs
@@ -1,5 +1,5 @@
 using HotChocolate.Types;
-using Nikcio.UHeadless.Basics.Properties.Models;
+using Nikcio.UHeadless.Base.Basics.Models;
 using Nikcio.UHeadless.Content.Basics.Models;
 using Nikcio.UHeadless.Content.Queries;
 using Nikcio.UHeadless.Core.GraphQL.Queries;

--- a/src/Nikcio.UHeadless.Content/Basics/Queries/BasicContentDescendantsByAbsoluteRouteQuery.cs
+++ b/src/Nikcio.UHeadless.Content/Basics/Queries/BasicContentDescendantsByAbsoluteRouteQuery.cs
@@ -1,5 +1,5 @@
 using HotChocolate.Types;
-using Nikcio.UHeadless.Basics.Properties.Models;
+using Nikcio.UHeadless.Base.Basics.Models;
 using Nikcio.UHeadless.Content.Basics.Models;
 using Nikcio.UHeadless.Content.Queries;
 using Nikcio.UHeadless.Core.GraphQL.Queries;

--- a/src/Nikcio.UHeadless.Content/Basics/Queries/BasicContentDescendantsByContentTypeQuery.cs
+++ b/src/Nikcio.UHeadless.Content/Basics/Queries/BasicContentDescendantsByContentTypeQuery.cs
@@ -1,5 +1,5 @@
 using HotChocolate.Types;
-using Nikcio.UHeadless.Basics.Properties.Models;
+using Nikcio.UHeadless.Base.Basics.Models;
 using Nikcio.UHeadless.Content.Basics.Models;
 using Nikcio.UHeadless.Content.Queries;
 using Nikcio.UHeadless.Core.GraphQL.Queries;

--- a/src/Nikcio.UHeadless.Content/Basics/Queries/BasicContentDescendantsByGuidQuery.cs
+++ b/src/Nikcio.UHeadless.Content/Basics/Queries/BasicContentDescendantsByGuidQuery.cs
@@ -1,5 +1,5 @@
 using HotChocolate.Types;
-using Nikcio.UHeadless.Basics.Properties.Models;
+using Nikcio.UHeadless.Base.Basics.Models;
 using Nikcio.UHeadless.Content.Basics.Models;
 using Nikcio.UHeadless.Content.Queries;
 using Nikcio.UHeadless.Core.GraphQL.Queries;

--- a/src/Nikcio.UHeadless.Content/Basics/Queries/BasicContentDescendantsByIdQuery.cs
+++ b/src/Nikcio.UHeadless.Content/Basics/Queries/BasicContentDescendantsByIdQuery.cs
@@ -1,5 +1,5 @@
 using HotChocolate.Types;
-using Nikcio.UHeadless.Basics.Properties.Models;
+using Nikcio.UHeadless.Base.Basics.Models;
 using Nikcio.UHeadless.Content.Basics.Models;
 using Nikcio.UHeadless.Content.Queries;
 using Nikcio.UHeadless.Core.GraphQL.Queries;

--- a/src/Nikcio.UHeadless.IntegrationTests/Content/Queries/ContentAll/ContentAllTests.cs
+++ b/src/Nikcio.UHeadless.IntegrationTests/Content/Queries/ContentAll/ContentAllTests.cs
@@ -2,7 +2,7 @@ using Nikcio.UHeadless.IntegrationTests.Extensions;
 using Nikcio.UHeadless.IntegrationTests.Shared;
 using StrawberryShake;
 
-namespace Nikcio.UHeadless.IntegrationTests.Content.Queries;
+namespace Nikcio.UHeadless.IntegrationTests.Content.Queries.ContentAll;
 
 public class ContentAllTests : IntegrationTestBase
 {

--- a/src/Nikcio.UHeadless.IntegrationTests/Content/Queries/ContentAtRoot/ContentAtRootTests.cs
+++ b/src/Nikcio.UHeadless.IntegrationTests/Content/Queries/ContentAtRoot/ContentAtRootTests.cs
@@ -2,7 +2,7 @@ using Nikcio.UHeadless.IntegrationTests.Extensions;
 using Nikcio.UHeadless.IntegrationTests.Shared;
 using StrawberryShake;
 
-namespace Nikcio.UHeadless.IntegrationTests.Content.Queries;
+namespace Nikcio.UHeadless.IntegrationTests.Content.Queries.ContentAtRoot;
 
 public class ContentAtRootTests : IntegrationTestBase
 {

--- a/src/Nikcio.UHeadless.IntegrationTests/Content/Queries/ContentByAbsoluteRoute/ContentByAbsoluteRouteTests.cs
+++ b/src/Nikcio.UHeadless.IntegrationTests/Content/Queries/ContentByAbsoluteRoute/ContentByAbsoluteRouteTests.cs
@@ -2,7 +2,7 @@ using Nikcio.UHeadless.IntegrationTests.Extensions;
 using Nikcio.UHeadless.IntegrationTests.Shared;
 using StrawberryShake;
 
-namespace Nikcio.UHeadless.IntegrationTests.Content.Queries;
+namespace Nikcio.UHeadless.IntegrationTests.Content.Queries.ContentByAbsoluteRoute;
 
 public class ContentByAbsoluteRouteTests : IntegrationTestBase
 {

--- a/src/Nikcio.UHeadless.IntegrationTests/Content/Queries/ContentByContentType/ContentByContentTypeTests.cs
+++ b/src/Nikcio.UHeadless.IntegrationTests/Content/Queries/ContentByContentType/ContentByContentTypeTests.cs
@@ -2,7 +2,7 @@ using Nikcio.UHeadless.IntegrationTests.Extensions;
 using Nikcio.UHeadless.IntegrationTests.Shared;
 using StrawberryShake;
 
-namespace Nikcio.UHeadless.IntegrationTests.Content.Queries;
+namespace Nikcio.UHeadless.IntegrationTests.Content.Queries.ContentByContentType;
 
 public class ContentByContentTypeTests : IntegrationTestBase
 {

--- a/src/Nikcio.UHeadless.IntegrationTests/Content/Queries/ContentByGuid/ContentByGuidTests.cs
+++ b/src/Nikcio.UHeadless.IntegrationTests/Content/Queries/ContentByGuid/ContentByGuidTests.cs
@@ -2,7 +2,7 @@ using Nikcio.UHeadless.IntegrationTests.Extensions;
 using Nikcio.UHeadless.IntegrationTests.Shared;
 using StrawberryShake;
 
-namespace Nikcio.UHeadless.IntegrationTests.Content.Queries;
+namespace Nikcio.UHeadless.IntegrationTests.Content.Queries.ContentByGuid;
 
 public class ContentByGuidTests : IntegrationTestBase
 {

--- a/src/Nikcio.UHeadless.IntegrationTests/Content/Queries/ContentById/ContentByIdTests.cs
+++ b/src/Nikcio.UHeadless.IntegrationTests/Content/Queries/ContentById/ContentByIdTests.cs
@@ -2,7 +2,7 @@ using Nikcio.UHeadless.IntegrationTests.Extensions;
 using Nikcio.UHeadless.IntegrationTests.Shared;
 using StrawberryShake;
 
-namespace Nikcio.UHeadless.IntegrationTests.Content.Queries;
+namespace Nikcio.UHeadless.IntegrationTests.Content.Queries.ContentById;
 
 public class ContentByIdTests : IntegrationTestBase
 {

--- a/src/Nikcio.UHeadless.IntegrationTests/Content/Queries/ContentByTag/ContentByTagTests.cs
+++ b/src/Nikcio.UHeadless.IntegrationTests/Content/Queries/ContentByTag/ContentByTagTests.cs
@@ -2,7 +2,7 @@ using Nikcio.UHeadless.IntegrationTests.Extensions;
 using Nikcio.UHeadless.IntegrationTests.Shared;
 using StrawberryShake;
 
-namespace Nikcio.UHeadless.IntegrationTests.Content.Queries;
+namespace Nikcio.UHeadless.IntegrationTests.Content.Queries.ContentByTag;
 
 public class ContentByTagTests : IntegrationTestBase
 {

--- a/src/Nikcio.UHeadless.IntegrationTests/Content/Queries/ContentDescendantsByAbsoluteRoute/ContentDescendantsByAbsoluteRouteTests.cs
+++ b/src/Nikcio.UHeadless.IntegrationTests/Content/Queries/ContentDescendantsByAbsoluteRoute/ContentDescendantsByAbsoluteRouteTests.cs
@@ -2,7 +2,7 @@ using Nikcio.UHeadless.IntegrationTests.Extensions;
 using Nikcio.UHeadless.IntegrationTests.Shared;
 using StrawberryShake;
 
-namespace Nikcio.UHeadless.IntegrationTests.Content.Queries;
+namespace Nikcio.UHeadless.IntegrationTests.Content.Queries.ContentDescendantsByAbsoluteRoute;
 
 public class ContentDescendantsByAbsoluteRouteTests : IntegrationTestBase
 {

--- a/src/Nikcio.UHeadless.IntegrationTests/Content/Queries/ContentDescendantsByContentType/ContentDescendantsByContentTypeTests.cs
+++ b/src/Nikcio.UHeadless.IntegrationTests/Content/Queries/ContentDescendantsByContentType/ContentDescendantsByContentTypeTests.cs
@@ -2,7 +2,7 @@ using Nikcio.UHeadless.IntegrationTests.Extensions;
 using Nikcio.UHeadless.IntegrationTests.Shared;
 using StrawberryShake;
 
-namespace Nikcio.UHeadless.IntegrationTests.Content.Queries;
+namespace Nikcio.UHeadless.IntegrationTests.Content.Queries.ContentDescendantsByContentType;
 
 public class ContentDescendantsByContentTypeTests : IntegrationTestBase
 {

--- a/src/Nikcio.UHeadless.IntegrationTests/Content/Queries/ContentDescendantsByGuid/ContentDescendantsByGuid.cs
+++ b/src/Nikcio.UHeadless.IntegrationTests/Content/Queries/ContentDescendantsByGuid/ContentDescendantsByGuid.cs
@@ -2,7 +2,7 @@ using Nikcio.UHeadless.IntegrationTests.Extensions;
 using Nikcio.UHeadless.IntegrationTests.Shared;
 using StrawberryShake;
 
-namespace Nikcio.UHeadless.IntegrationTests.Content.Queries;
+namespace Nikcio.UHeadless.IntegrationTests.Content.Queries.ContentDescendantsByGuid;
 
 public class ContentDescendantsByGuidTests : IntegrationTestBase
 {

--- a/src/Nikcio.UHeadless.IntegrationTests/Content/Queries/ContentDescendantsById/ContentDescendantsById.cs
+++ b/src/Nikcio.UHeadless.IntegrationTests/Content/Queries/ContentDescendantsById/ContentDescendantsById.cs
@@ -2,7 +2,7 @@ using Nikcio.UHeadless.IntegrationTests.Extensions;
 using Nikcio.UHeadless.IntegrationTests.Shared;
 using StrawberryShake;
 
-namespace Nikcio.UHeadless.IntegrationTests.Content.Queries;
+namespace Nikcio.UHeadless.IntegrationTests.Content.Queries.ContentDescendantsById;
 
 public class ContentDescendantsByIdTests : IntegrationTestBase
 {

--- a/src/Nikcio.UHeadless.IntegrationTests/Media/Queries/MediaAtRoot/MediaAtRootTests.cs
+++ b/src/Nikcio.UHeadless.IntegrationTests/Media/Queries/MediaAtRoot/MediaAtRootTests.cs
@@ -2,7 +2,7 @@ using Nikcio.UHeadless.IntegrationTests.Extensions;
 using Nikcio.UHeadless.IntegrationTests.Shared;
 using StrawberryShake;
 
-namespace Nikcio.UHeadless.IntegrationTests.Media.Queries;
+namespace Nikcio.UHeadless.IntegrationTests.Media.Queries.MediaAtRoot;
 
 public class MediaAtRootTests : IntegrationTestBase
 {

--- a/src/Nikcio.UHeadless.IntegrationTests/Media/Queries/MediaByContentType/MediaByContentTypeTests.cs
+++ b/src/Nikcio.UHeadless.IntegrationTests/Media/Queries/MediaByContentType/MediaByContentTypeTests.cs
@@ -2,7 +2,7 @@ using Nikcio.UHeadless.IntegrationTests.Extensions;
 using Nikcio.UHeadless.IntegrationTests.Shared;
 using StrawberryShake;
 
-namespace Nikcio.UHeadless.IntegrationTests.Media.Queries;
+namespace Nikcio.UHeadless.IntegrationTests.Media.Queries.MediaByContentType;
 
 public class MediaByContentTypeTests : IntegrationTestBase
 {

--- a/src/Nikcio.UHeadless.IntegrationTests/Media/Queries/MediaByGuid/MediaByGuidTests.cs
+++ b/src/Nikcio.UHeadless.IntegrationTests/Media/Queries/MediaByGuid/MediaByGuidTests.cs
@@ -2,7 +2,7 @@ using Nikcio.UHeadless.IntegrationTests.Extensions;
 using Nikcio.UHeadless.IntegrationTests.Shared;
 using StrawberryShake;
 
-namespace Nikcio.UHeadless.IntegrationTests.Media.Queries;
+namespace Nikcio.UHeadless.IntegrationTests.Media.Queries.MediaByGuid;
 
 public class MediaByGuidTests : IntegrationTestBase
 {

--- a/src/Nikcio.UHeadless.IntegrationTests/Media/Queries/MediaById/MediaByIdTests.cs
+++ b/src/Nikcio.UHeadless.IntegrationTests/Media/Queries/MediaById/MediaByIdTests.cs
@@ -2,7 +2,7 @@ using Nikcio.UHeadless.IntegrationTests.Extensions;
 using Nikcio.UHeadless.IntegrationTests.Shared;
 using StrawberryShake;
 
-namespace Nikcio.UHeadless.IntegrationTests.Media.Queries;
+namespace Nikcio.UHeadless.IntegrationTests.Media.Queries.MediaById;
 
 public class MediaByIdTests : IntegrationTestBase
 {

--- a/src/Nikcio.UHeadless.Media/Basics/Models/BasicMedia.cs
+++ b/src/Nikcio.UHeadless.Media/Basics/Models/BasicMedia.cs
@@ -1,8 +1,8 @@
 ﻿using HotChocolate;
 using HotChocolate.Data;
+using Nikcio.UHeadless.Base.Basics.Models;
 using Nikcio.UHeadless.Base.Properties.Factories;
 using Nikcio.UHeadless.Base.Properties.Models;
-using Nikcio.UHeadless.Basics.Properties.Models;
 using Nikcio.UHeadless.ContentTypes.Basics.Models;
 using Nikcio.UHeadless.ContentTypes.Factories;
 using Nikcio.UHeadless.ContentTypes.Models;

--- a/src/Nikcio.UHeadless.Media/Basics/Queries/AuthMediaAtRootQuery.cs
+++ b/src/Nikcio.UHeadless.Media/Basics/Queries/AuthMediaAtRootQuery.cs
@@ -1,7 +1,7 @@
 using HotChocolate;
 using HotChocolate.Authorization;
 using HotChocolate.Types;
-using Nikcio.UHeadless.Basics.Properties.Models;
+using Nikcio.UHeadless.Base.Basics.Models;
 using Nikcio.UHeadless.Core.GraphQL.Queries;
 using Nikcio.UHeadless.Media.Basics.Models;
 using Nikcio.UHeadless.Media.Queries;

--- a/src/Nikcio.UHeadless.Media/Basics/Queries/AuthMediaByContentTypeQuery.cs
+++ b/src/Nikcio.UHeadless.Media/Basics/Queries/AuthMediaByContentTypeQuery.cs
@@ -1,7 +1,7 @@
 using HotChocolate;
 using HotChocolate.Authorization;
 using HotChocolate.Types;
-using Nikcio.UHeadless.Basics.Properties.Models;
+using Nikcio.UHeadless.Base.Basics.Models;
 using Nikcio.UHeadless.Core.GraphQL.Queries;
 using Nikcio.UHeadless.Media.Basics.Models;
 using Nikcio.UHeadless.Media.Queries;

--- a/src/Nikcio.UHeadless.Media/Basics/Queries/AuthMediaByGuidQuery.cs
+++ b/src/Nikcio.UHeadless.Media/Basics/Queries/AuthMediaByGuidQuery.cs
@@ -1,7 +1,7 @@
 using HotChocolate;
 using HotChocolate.Authorization;
 using HotChocolate.Types;
-using Nikcio.UHeadless.Basics.Properties.Models;
+using Nikcio.UHeadless.Base.Basics.Models;
 using Nikcio.UHeadless.Core.GraphQL.Queries;
 using Nikcio.UHeadless.Media.Basics.Models;
 using Nikcio.UHeadless.Media.Queries;

--- a/src/Nikcio.UHeadless.Media/Basics/Queries/AuthMediaByIdQuery.cs
+++ b/src/Nikcio.UHeadless.Media/Basics/Queries/AuthMediaByIdQuery.cs
@@ -1,7 +1,7 @@
 using HotChocolate;
 using HotChocolate.Authorization;
 using HotChocolate.Types;
-using Nikcio.UHeadless.Basics.Properties.Models;
+using Nikcio.UHeadless.Base.Basics.Models;
 using Nikcio.UHeadless.Core.GraphQL.Queries;
 using Nikcio.UHeadless.Media.Basics.Models;
 using Nikcio.UHeadless.Media.Queries;

--- a/src/Nikcio.UHeadless.Media/Basics/Queries/BasicMediaAtRootQuery.cs
+++ b/src/Nikcio.UHeadless.Media/Basics/Queries/BasicMediaAtRootQuery.cs
@@ -1,5 +1,5 @@
 using HotChocolate.Types;
-using Nikcio.UHeadless.Basics.Properties.Models;
+using Nikcio.UHeadless.Base.Basics.Models;
 using Nikcio.UHeadless.Core.GraphQL.Queries;
 using Nikcio.UHeadless.Media.Basics.Models;
 using Nikcio.UHeadless.Media.Queries;

--- a/src/Nikcio.UHeadless.Media/Basics/Queries/BasicMediaByContentTypeQuery.cs
+++ b/src/Nikcio.UHeadless.Media/Basics/Queries/BasicMediaByContentTypeQuery.cs
@@ -1,5 +1,5 @@
 using HotChocolate.Types;
-using Nikcio.UHeadless.Basics.Properties.Models;
+using Nikcio.UHeadless.Base.Basics.Models;
 using Nikcio.UHeadless.Core.GraphQL.Queries;
 using Nikcio.UHeadless.Media.Basics.Models;
 using Nikcio.UHeadless.Media.Queries;

--- a/src/Nikcio.UHeadless.Media/Basics/Queries/BasicMediaByGuidQuery.cs
+++ b/src/Nikcio.UHeadless.Media/Basics/Queries/BasicMediaByGuidQuery.cs
@@ -1,5 +1,5 @@
 using HotChocolate.Types;
-using Nikcio.UHeadless.Basics.Properties.Models;
+using Nikcio.UHeadless.Base.Basics.Models;
 using Nikcio.UHeadless.Core.GraphQL.Queries;
 using Nikcio.UHeadless.Media.Basics.Models;
 using Nikcio.UHeadless.Media.Queries;

--- a/src/Nikcio.UHeadless.Media/Basics/Queries/BasicMediaByIdQuery.cs
+++ b/src/Nikcio.UHeadless.Media/Basics/Queries/BasicMediaByIdQuery.cs
@@ -1,5 +1,5 @@
 using HotChocolate.Types;
-using Nikcio.UHeadless.Basics.Properties.Models;
+using Nikcio.UHeadless.Base.Basics.Models;
 using Nikcio.UHeadless.Core.GraphQL.Queries;
 using Nikcio.UHeadless.Media.Basics.Models;
 using Nikcio.UHeadless.Media.Queries;

--- a/src/Nikcio.UHeadless.Members/Basics/Models/BasicMember.cs
+++ b/src/Nikcio.UHeadless.Members/Basics/Models/BasicMember.cs
@@ -1,6 +1,6 @@
 ﻿using HotChocolate;
+using Nikcio.UHeadless.Base.Basics.Models;
 using Nikcio.UHeadless.Base.Properties.Factories;
-using Nikcio.UHeadless.Basics.Properties.Models;
 using Nikcio.UHeadless.Members.Commands;
 using Nikcio.UHeadless.Members.Models;
 

--- a/src/Nikcio.UHeadless.Members/Basics/Queries/AuthAllMembersQuery.cs
+++ b/src/Nikcio.UHeadless.Members/Basics/Queries/AuthAllMembersQuery.cs
@@ -1,7 +1,7 @@
 ﻿using HotChocolate;
 using HotChocolate.Authorization;
 using HotChocolate.Types;
-using Nikcio.UHeadless.Basics.Properties.Models;
+using Nikcio.UHeadless.Base.Basics.Models;
 using Nikcio.UHeadless.Core.GraphQL.Queries;
 using Nikcio.UHeadless.Members.Basics.Models;
 using Nikcio.UHeadless.Members.Queries;

--- a/src/Nikcio.UHeadless.Members/Basics/Queries/AuthFindMembersByDisplayNameQuery.cs
+++ b/src/Nikcio.UHeadless.Members/Basics/Queries/AuthFindMembersByDisplayNameQuery.cs
@@ -1,7 +1,7 @@
 ﻿using HotChocolate;
 using HotChocolate.Authorization;
 using HotChocolate.Types;
-using Nikcio.UHeadless.Basics.Properties.Models;
+using Nikcio.UHeadless.Base.Basics.Models;
 using Nikcio.UHeadless.Core.GraphQL.Queries;
 using Nikcio.UHeadless.Members.Basics.Models;
 using Nikcio.UHeadless.Members.Queries;

--- a/src/Nikcio.UHeadless.Members/Basics/Queries/AuthFindMembersByEmailQuery.cs
+++ b/src/Nikcio.UHeadless.Members/Basics/Queries/AuthFindMembersByEmailQuery.cs
@@ -1,7 +1,7 @@
 ﻿using HotChocolate;
 using HotChocolate.Authorization;
 using HotChocolate.Types;
-using Nikcio.UHeadless.Basics.Properties.Models;
+using Nikcio.UHeadless.Base.Basics.Models;
 using Nikcio.UHeadless.Core.GraphQL.Queries;
 using Nikcio.UHeadless.Members.Basics.Models;
 using Nikcio.UHeadless.Members.Queries;

--- a/src/Nikcio.UHeadless.Members/Basics/Queries/AuthFindMembersByRoleQuery.cs
+++ b/src/Nikcio.UHeadless.Members/Basics/Queries/AuthFindMembersByRoleQuery.cs
@@ -1,7 +1,7 @@
 ﻿using HotChocolate;
 using HotChocolate.Authorization;
 using HotChocolate.Types;
-using Nikcio.UHeadless.Basics.Properties.Models;
+using Nikcio.UHeadless.Base.Basics.Models;
 using Nikcio.UHeadless.Core.GraphQL.Queries;
 using Nikcio.UHeadless.Members.Basics.Models;
 using Nikcio.UHeadless.Members.Queries;

--- a/src/Nikcio.UHeadless.Members/Basics/Queries/AuthFindMembersByUsernameQuery.cs
+++ b/src/Nikcio.UHeadless.Members/Basics/Queries/AuthFindMembersByUsernameQuery.cs
@@ -1,7 +1,7 @@
 ﻿using HotChocolate;
 using HotChocolate.Authorization;
 using HotChocolate.Types;
-using Nikcio.UHeadless.Basics.Properties.Models;
+using Nikcio.UHeadless.Base.Basics.Models;
 using Nikcio.UHeadless.Core.GraphQL.Queries;
 using Nikcio.UHeadless.Members.Basics.Models;
 using Nikcio.UHeadless.Members.Queries;

--- a/src/Nikcio.UHeadless.Members/Basics/Queries/AuthMemberByEmailQuery.cs
+++ b/src/Nikcio.UHeadless.Members/Basics/Queries/AuthMemberByEmailQuery.cs
@@ -1,7 +1,7 @@
 ﻿using HotChocolate;
 using HotChocolate.Authorization;
 using HotChocolate.Types;
-using Nikcio.UHeadless.Basics.Properties.Models;
+using Nikcio.UHeadless.Base.Basics.Models;
 using Nikcio.UHeadless.Core.GraphQL.Queries;
 using Nikcio.UHeadless.Members.Basics.Models;
 using Nikcio.UHeadless.Members.Queries;

--- a/src/Nikcio.UHeadless.Members/Basics/Queries/AuthMemberByIdQuery.cs
+++ b/src/Nikcio.UHeadless.Members/Basics/Queries/AuthMemberByIdQuery.cs
@@ -1,7 +1,7 @@
 ﻿using HotChocolate;
 using HotChocolate.Authorization;
 using HotChocolate.Types;
-using Nikcio.UHeadless.Basics.Properties.Models;
+using Nikcio.UHeadless.Base.Basics.Models;
 using Nikcio.UHeadless.Core.GraphQL.Queries;
 using Nikcio.UHeadless.Members.Basics.Models;
 using Nikcio.UHeadless.Members.Queries;

--- a/src/Nikcio.UHeadless.Members/Basics/Queries/AuthMemberByKeyQuery.cs
+++ b/src/Nikcio.UHeadless.Members/Basics/Queries/AuthMemberByKeyQuery.cs
@@ -1,7 +1,7 @@
 ﻿using HotChocolate;
 using HotChocolate.Authorization;
 using HotChocolate.Types;
-using Nikcio.UHeadless.Basics.Properties.Models;
+using Nikcio.UHeadless.Base.Basics.Models;
 using Nikcio.UHeadless.Core.GraphQL.Queries;
 using Nikcio.UHeadless.Members.Basics.Models;
 using Nikcio.UHeadless.Members.Queries;

--- a/src/Nikcio.UHeadless.Members/Basics/Queries/AuthMemberByUsernameQuery.cs
+++ b/src/Nikcio.UHeadless.Members/Basics/Queries/AuthMemberByUsernameQuery.cs
@@ -1,7 +1,7 @@
 ﻿using HotChocolate;
 using HotChocolate.Authorization;
 using HotChocolate.Types;
-using Nikcio.UHeadless.Basics.Properties.Models;
+using Nikcio.UHeadless.Base.Basics.Models;
 using Nikcio.UHeadless.Core.GraphQL.Queries;
 using Nikcio.UHeadless.Members.Basics.Models;
 using Nikcio.UHeadless.Members.Queries;

--- a/src/Nikcio.UHeadless.Members/Basics/Queries/AuthMembersByIdQuery.cs
+++ b/src/Nikcio.UHeadless.Members/Basics/Queries/AuthMembersByIdQuery.cs
@@ -1,7 +1,7 @@
 ﻿using HotChocolate;
 using HotChocolate.Authorization;
 using HotChocolate.Types;
-using Nikcio.UHeadless.Basics.Properties.Models;
+using Nikcio.UHeadless.Base.Basics.Models;
 using Nikcio.UHeadless.Core.GraphQL.Queries;
 using Nikcio.UHeadless.Members.Basics.Models;
 using Nikcio.UHeadless.Members.Queries;

--- a/src/Nikcio.UHeadless.Members/Basics/Queries/BasicAllMembersQuery.cs
+++ b/src/Nikcio.UHeadless.Members/Basics/Queries/BasicAllMembersQuery.cs
@@ -1,5 +1,5 @@
 ﻿using HotChocolate.Types;
-using Nikcio.UHeadless.Basics.Properties.Models;
+using Nikcio.UHeadless.Base.Basics.Models;
 using Nikcio.UHeadless.Core.GraphQL.Queries;
 using Nikcio.UHeadless.Members.Basics.Models;
 using Nikcio.UHeadless.Members.Queries;

--- a/src/Nikcio.UHeadless.Members/Basics/Queries/BasicFindMembersByDisplayNameQuery.cs
+++ b/src/Nikcio.UHeadless.Members/Basics/Queries/BasicFindMembersByDisplayNameQuery.cs
@@ -1,5 +1,5 @@
 ﻿using HotChocolate.Types;
-using Nikcio.UHeadless.Basics.Properties.Models;
+using Nikcio.UHeadless.Base.Basics.Models;
 using Nikcio.UHeadless.Core.GraphQL.Queries;
 using Nikcio.UHeadless.Members.Basics.Models;
 using Nikcio.UHeadless.Members.Queries;

--- a/src/Nikcio.UHeadless.Members/Basics/Queries/BasicFindMembersByEmailQuery.cs
+++ b/src/Nikcio.UHeadless.Members/Basics/Queries/BasicFindMembersByEmailQuery.cs
@@ -1,5 +1,5 @@
 ﻿using HotChocolate.Types;
-using Nikcio.UHeadless.Basics.Properties.Models;
+using Nikcio.UHeadless.Base.Basics.Models;
 using Nikcio.UHeadless.Core.GraphQL.Queries;
 using Nikcio.UHeadless.Members.Basics.Models;
 using Nikcio.UHeadless.Members.Queries;

--- a/src/Nikcio.UHeadless.Members/Basics/Queries/BasicFindMembersByRoleQuery.cs
+++ b/src/Nikcio.UHeadless.Members/Basics/Queries/BasicFindMembersByRoleQuery.cs
@@ -1,5 +1,5 @@
 ﻿using HotChocolate.Types;
-using Nikcio.UHeadless.Basics.Properties.Models;
+using Nikcio.UHeadless.Base.Basics.Models;
 using Nikcio.UHeadless.Core.GraphQL.Queries;
 using Nikcio.UHeadless.Members.Basics.Models;
 using Nikcio.UHeadless.Members.Queries;

--- a/src/Nikcio.UHeadless.Members/Basics/Queries/BasicFindMembersByUsernameQuery.cs
+++ b/src/Nikcio.UHeadless.Members/Basics/Queries/BasicFindMembersByUsernameQuery.cs
@@ -1,5 +1,5 @@
 ﻿using HotChocolate.Types;
-using Nikcio.UHeadless.Basics.Properties.Models;
+using Nikcio.UHeadless.Base.Basics.Models;
 using Nikcio.UHeadless.Core.GraphQL.Queries;
 using Nikcio.UHeadless.Members.Basics.Models;
 using Nikcio.UHeadless.Members.Queries;

--- a/src/Nikcio.UHeadless.Members/Basics/Queries/BasicMemberByEmailQuery.cs
+++ b/src/Nikcio.UHeadless.Members/Basics/Queries/BasicMemberByEmailQuery.cs
@@ -1,5 +1,5 @@
 ﻿using HotChocolate.Types;
-using Nikcio.UHeadless.Basics.Properties.Models;
+using Nikcio.UHeadless.Base.Basics.Models;
 using Nikcio.UHeadless.Core.GraphQL.Queries;
 using Nikcio.UHeadless.Members.Basics.Models;
 using Nikcio.UHeadless.Members.Queries;

--- a/src/Nikcio.UHeadless.Members/Basics/Queries/BasicMemberByIdQuery.cs
+++ b/src/Nikcio.UHeadless.Members/Basics/Queries/BasicMemberByIdQuery.cs
@@ -1,5 +1,5 @@
 ﻿using HotChocolate.Types;
-using Nikcio.UHeadless.Basics.Properties.Models;
+using Nikcio.UHeadless.Base.Basics.Models;
 using Nikcio.UHeadless.Core.GraphQL.Queries;
 using Nikcio.UHeadless.Members.Basics.Models;
 using Nikcio.UHeadless.Members.Queries;

--- a/src/Nikcio.UHeadless.Members/Basics/Queries/BasicMemberByKeyQuery.cs
+++ b/src/Nikcio.UHeadless.Members/Basics/Queries/BasicMemberByKeyQuery.cs
@@ -1,5 +1,5 @@
 ﻿using HotChocolate.Types;
-using Nikcio.UHeadless.Basics.Properties.Models;
+using Nikcio.UHeadless.Base.Basics.Models;
 using Nikcio.UHeadless.Core.GraphQL.Queries;
 using Nikcio.UHeadless.Members.Basics.Models;
 using Nikcio.UHeadless.Members.Queries;

--- a/src/Nikcio.UHeadless.Members/Basics/Queries/BasicMemberByUsernameQuery.cs
+++ b/src/Nikcio.UHeadless.Members/Basics/Queries/BasicMemberByUsernameQuery.cs
@@ -1,5 +1,5 @@
 ﻿using HotChocolate.Types;
-using Nikcio.UHeadless.Basics.Properties.Models;
+using Nikcio.UHeadless.Base.Basics.Models;
 using Nikcio.UHeadless.Core.GraphQL.Queries;
 using Nikcio.UHeadless.Members.Basics.Models;
 using Nikcio.UHeadless.Members.Queries;

--- a/src/Nikcio.UHeadless.Members/Basics/Queries/BasicMembersByIdQuery.cs
+++ b/src/Nikcio.UHeadless.Members/Basics/Queries/BasicMembersByIdQuery.cs
@@ -1,5 +1,5 @@
 ﻿using HotChocolate.Types;
-using Nikcio.UHeadless.Basics.Properties.Models;
+using Nikcio.UHeadless.Base.Basics.Models;
 using Nikcio.UHeadless.Core.GraphQL.Queries;
 using Nikcio.UHeadless.Members.Basics.Models;
 using Nikcio.UHeadless.Members.Queries;

--- a/src/Nikcio.UHeadless/Extensions/UHeadlessExtensions.cs
+++ b/src/Nikcio.UHeadless/Extensions/UHeadlessExtensions.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
+using Nikcio.UHeadless.Base.Basics.Maps.Extensions;
 using Nikcio.UHeadless.Base.Properties.Extensions;
-using Nikcio.UHeadless.Basics.Properties.Maps.Extensions;
 using Nikcio.UHeadless.Content.Basics.Queries;
 using Nikcio.UHeadless.Content.Extensions;
 using Nikcio.UHeadless.ContentTypes.Extensions;


### PR DESCRIPTION
BREAKING CHANGE:

Some namespaces weren't synced properly to the location of the files. So to avoid confusion over source files the namespaces have been synced. New namespaces:

BasicBlockListItem - `Nikcio.UHeadless.Base.Basics.EditorsValues.BlockList.Models` 
BasicBlockListModel - `Nikcio.UHeadless.Base.Basics.EditorsValues.BlockList.Models` 
BasicContentPicker - `Nikcio.UHeadless.Base.Basics.EditorsValues.ContentPicker.Models` 
BasicContentPickerItem - `Nikcio.UHeadless.Base.Basics.EditorsValues.ContentPicker.Models` 
BasicDateTimePicker - `Nikcio.UHeadless.Base.Basics.EditorsValues.DateTimePicker.Models` 
BasicPropertyValue - `Nikcio.UHeadless.Base.Basics.EditorsValues.Fallback.Models` 
BasicMediaPicker - `Nikcio.UHeadless.Base.Basics.EditorsValues.MediaPicker.Models` 
BasicMediaPickerItem - `Nikcio.UHeadless.Base.Basics.EditorsValues.MediaPicker.Models` 
BasicMemberPicker - `Nikcio.UHeadless.Base.Basics.EditorsValues.MemberPicker.Models` 
BasicMemberPickerItem - `Nikcio.UHeadless.Base.Basics.EditorsValues.MemberPicker.Models` 
BasicMultiUrlPicker - `Nikcio.UHeadless.Base.Basics.EditorsValues.MultiUrlPicker.Models` 
BasicMultiUrlPickerItem - `Nikcio.UHeadless.Base.Basics.EditorsValues.MultiUrlPicker.Models` 
BasicNestedContent - `Nikcio.UHeadless.Base.Basics.EditorsValues.NestedContent.Models`
 BasicNestedContentElement - `Nikcio.UHeadless.Base.Basics.EditorsValues.NestedContent.Models` 
BasicRichText - `Nikcio.UHeadless.Base.Basics.EditorsValues.RichTextEditor.Models` 
PropertyMapExtensions - `Nikcio.UHeadless.Base.Basics.Maps.Extensions` 
BasicProperty - `Nikcio.UHeadless.Base.Basics.Models`