### PR TITLE
chore(deps): upgrade HotChocolate packages to latest patch versions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,10 +5,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
-    <PackageVersion Include="HotChocolate.AspNetCore" Version="15.1.13" />
-    <PackageVersion Include="HotChocolate.AspNetCore.Authorization" Version="15.1.13" />
-    <PackageVersion Include="HotChocolate.PersistedOperations.InMemory" Version="15.1.13" />
-    <PackageVersion Include="HotChocolate.PersistedQueries.InMemory" Version="13.9.14" />
+    <PackageVersion Include="HotChocolate.AspNetCore" Version="15.1.17" />
+    <PackageVersion Include="HotChocolate.AspNetCore.Authorization" Version="15.1.17" />
+    <PackageVersion Include="HotChocolate.PersistedOperations.InMemory" Version="15.1.17" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.1" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.5" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.1" />


### PR DESCRIPTION
## Summary

Upgrades HotChocolate dependencies to the latest patch versions without crossing a major version boundary.

## Changes

| Package | Old | New |
|---|---|---|
| HotChocolate.AspNetCore | 15.1.13 | 15.1.17 |
| HotChocolate.AspNetCore.Authorization | 15.1.13 | 15.1.17 |
| HotChocolate.PersistedOperations.InMemory | 15.1.13 | 15.1.17 |

Additionally, removed **HotChocolate.PersistedQueries.InMemory** (13.9.14) — no project references it and no code uses its types. It was a dead entry in `Directory.Packages.props`.
