### PR TITLE
chore(deps): update testing dependencies to latest versions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,13 +9,13 @@
     <PackageVersion Include="HotChocolate.AspNetCore.Authorization" Version="15.1.17" />
     <PackageVersion Include="HotChocolate.PersistedOperations.InMemory" Version="15.1.17" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.1" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.1" />
     <PackageVersion Include="Microsoft.ICU.ICU4C.Runtime" Version="72.1.0.3" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15" />
-    <PackageVersion Include="NSubstitute" Version="5.3.0" />
+    <PackageVersion Include="NSubstitute" Version="6.2.0" />
     <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
     <!-- <PackageVersion Include="Skybrud.Umbraco.Redirects" Version="14.0.0-alpha001" /> -->
     <PackageVersion Include="Umbraco.Cms" Version="17.2.2" />
@@ -23,7 +23,7 @@
     <!-- <PackageVersion Include="Umbraco.Community.Contentment" Version="6.0.0-alpha003" /> -->
     <!-- <PackageVersion Include="UrlTracker" Version="13.2.0" /> -->
     <PackageVersion Include="uSync" Version="17.0.4" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
-    <PackageVersion Include="xunit.v3" Version="3.2.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="4.0.0" />
+    <PackageVersion Include="xunit.v3" Version="4.0.0" />
   </ItemGroup>
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,0 +1,5 @@
+{
+    "test": {
+        "runner": "Microsoft.Testing.Platform"
+    }
+}

--- a/src/Nikcio.UHeadless.IntegrationTests/SnapshotProvider.cs
+++ b/src/Nikcio.UHeadless.IntegrationTests/SnapshotProvider.cs
@@ -30,7 +30,7 @@ public partial class SnapshotProvider
 
         await CreateSnapshotAsync(jsonContent, snapshotErrorPath).ConfigureAwait(true);
 
-        Assert.Equal(snapshot, jsonContent);
+        Assert.Equal(NormalizeLineEndings(snapshot), NormalizeLineEndings(jsonContent));
 
         // If the assertion passes we can delete the error snapshot
         File.Delete(snapshotErrorPath);
@@ -113,6 +113,8 @@ public partial class SnapshotProvider
 
     [GeneratedRegex("""(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3,})((\\u002B|\+)\d{2}:\d{2})""")]
     private static partial Regex DateTimeRegex();
+
+    private static string NormalizeLineEndings(string value) => value.Replace("\r\n", "\n").Replace("\r", "\n");
 }
 
 public class SnapshotNotFoundException : Exception


### PR DESCRIPTION
## Summary

Updates all testing-related dependencies to their latest versions.

## Changes

| Package | From | To |
|---|---|---|
| Microsoft.NET.Test.Sdk | 18.3.0 | 18.9.0 |
| Microsoft.AspNetCore.Mvc.Testing | 10.0.5 | 10.0.11 |
| NSubstitute | 5.3.0 | 6.2.0 |
| xunit.runner.visualstudio | 3.1.5 | 4.0.0 |
| xunit.v3 | 3.2.2 | 4.0.0 |

### Additional changes
- Added `global.json` to configure the Microsoft.Testing.Platform runner (required for .NET 10 SDK)
- Fixed snapshot comparison in `SnapshotProvider.cs` to normalize line endings before comparing, avoiding failures from `\r\n` vs `\n` differences

## Verification
- Build succeeds with 0 errors
- All 20 unit tests pass
- All 225 integration tests pass