### PR TITLE
chore(deps): update Microsoft.AspNetCore.* packages to 10.0.11

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,10 +8,10 @@
     <PackageVersion Include="HotChocolate.AspNetCore" Version="15.1.17" />
     <PackageVersion Include="HotChocolate.AspNetCore.Authorization" Version="15.1.17" />
     <PackageVersion Include="HotChocolate.PersistedOperations.InMemory" Version="15.1.17" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.11" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
     <PackageVersion Include="Microsoft.ICU.ICU4C.Runtime" Version="72.1.0.3" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="18.7.23" />


### PR DESCRIPTION
Updates the following centralized NuGet package versions in `Directory.Packages.props`:

- `Microsoft.AspNetCore.Authentication.JwtBearer`: 10.0.1 → 10.0.11
- `Microsoft.Extensions.DependencyInjection.Abstractions`: 10.0.1 → 10.0.11
- `Microsoft.Extensions.Logging.Abstractions`: 10.0.1 → 10.0.11

These are patch/dependency updates aligning the Microsoft.Extensions.\* and AspNetCore.Authentication packages with the already-updated `Microsoft.AspNetCore.Mvc.Testing` (10.0.11).