### PR TITLE
feat!: upgrade HotChocolate from 15.1.17 to 16.6.1

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "strawberryshake.tools": {
-      "version": "15.1.13",
+      "version": "16.6.1",
       "commands": [
         "dotnet-graphql"
       ]

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,9 +5,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
-    <PackageVersion Include="HotChocolate.AspNetCore" Version="15.1.17" />
-    <PackageVersion Include="HotChocolate.AspNetCore.Authorization" Version="15.1.17" />
-    <PackageVersion Include="HotChocolate.PersistedOperations.InMemory" Version="15.1.17" />
+    <PackageVersion Include="HotChocolate.AspNetCore" Version="16.6.1" />
+    <PackageVersion Include="HotChocolate.AspNetCore.Authorization" Version="16.6.1" />
+    <PackageVersion Include="HotChocolate.PersistedOperations.InMemory" Version="16.6.1" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.11" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.11" />

--- a/examples/starter-example/Program.cs
+++ b/examples/starter-example/Program.cs
@@ -53,12 +53,9 @@ GraphQLEndpointConventionBuilder graphQLEndpointBuilder = app.MapUHeadless();
 // Only enable the GraphQL IDE in development
 if (!builder.Environment.IsDevelopment())
 {
-    graphQLEndpointBuilder.WithOptions(new GraphQLServerOptions()
+    graphQLEndpointBuilder.WithOptions(options =>
     {
-        Tool =
-        {
-            Enable = false,
-        }
+        options.Tool.Enable = false;
     });
 }
 

--- a/src/Nikcio.UHeadless.IntegrationTests.TestProject/GraphQLErrorFilter.cs
+++ b/src/Nikcio.UHeadless.IntegrationTests.TestProject/GraphQLErrorFilter.cs
@@ -1,4 +1,5 @@
 using HotChocolate;
+using HotChocolate.Execution;
 
 namespace Nikcio.UHeadless.IntegrationTests.TestProject;
 

--- a/src/Nikcio.UHeadless.IntegrationTests.TestProject/Program.cs
+++ b/src/Nikcio.UHeadless.IntegrationTests.TestProject/Program.cs
@@ -11,8 +11,6 @@ public sealed class Program
     {
         WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
-        builder.Services.AddErrorFilter<GraphQLErrorFilter>();
-
         builder.Services.ConfigureOptions<ConfigureExamineIndexes>();
 
 
@@ -65,6 +63,10 @@ public sealed class Program
                 {
                     parserOptions.MaxAllowedFields = 10000;
                 });
+
+                options.RequestExecutorBuilder
+                    .AddApplicationService<ILogger<GraphQLErrorFilter>>()
+                    .AddErrorFilter<GraphQLErrorFilter>();
             });
         }
 

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/Auth/ContentAtRoot/Snaps/ContentAtRoot_Snaps_test-3.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/Auth/ContentAtRoot/Snaps/ContentAtRoot_Snaps_test-3.snap
@@ -2,12 +2,6 @@
   "errors": [
     {
       "message": "The current user is not authorized to access this resource.",
-      "locations": [
-        {
-          "line": 10,
-          "column": 3
-        }
-      ],
       "path": [
         "contentAtRoot"
       ],

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/Auth/ContentByContentType/Snaps/ContentByContentType_Snaps_test-1.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/Auth/ContentByContentType/Snaps/ContentByContentType_Snaps_test-1.snap
@@ -2,12 +2,6 @@
   "errors": [
     {
       "message": "The current user is not authorized to access this resource.",
-      "locations": [
-        {
-          "line": 358,
-          "column": 7
-        }
-      ],
       "path": [
         "contentByContentType",
         "items",
@@ -241,7 +235,7 @@
             },
             "colorPicker": {
               "value": {
-                "color": "bf9000",
+                "value": "bf9000",
                 "label": "bf9000"
               },
               "model": "DefaultProperty",

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/Auth/ContentByContentType/Snaps/ContentByContentType_Snaps_test-2.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/Auth/ContentByContentType/Snaps/ContentByContentType_Snaps_test-2.snap
@@ -2,12 +2,6 @@
   "errors": [
     {
       "message": "The current user is not authorized to access this resource.",
-      "locations": [
-        {
-          "line": 358,
-          "column": 7
-        }
-      ],
       "path": [
         "contentByContentType",
         "items",
@@ -241,7 +235,7 @@
             },
             "colorPicker": {
               "value": {
-                "color": "bf9000",
+                "value": "bf9000",
                 "label": "bf9000"
               },
               "model": "DefaultProperty",

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/Auth/ContentByContentType/Snaps/ContentByContentType_Snaps_test-3.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/Auth/ContentByContentType/Snaps/ContentByContentType_Snaps_test-3.snap
@@ -223,7 +223,7 @@
             },
             "colorPicker": {
               "value": {
-                "color": "bf9000",
+                "value": "bf9000",
                 "label": "bf9000"
               },
               "model": "DefaultProperty",

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/Auth/ContentByContentType/Snaps/ContentByContentType_Snaps_test-4.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/Auth/ContentByContentType/Snaps/ContentByContentType_Snaps_test-4.snap
@@ -223,7 +223,7 @@
             },
             "colorPicker": {
               "value": {
-                "color": "bf9000",
+                "value": "bf9000",
                 "label": "bf9000"
               },
               "model": "DefaultProperty",

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/Auth/ContentByContentType/Snaps/ContentByContentType_Snaps_test-5.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/Auth/ContentByContentType/Snaps/ContentByContentType_Snaps_test-5.snap
@@ -2,12 +2,6 @@
   "errors": [
     {
       "message": "The current user is not authorized to access this resource.",
-      "locations": [
-        {
-          "line": 11,
-          "column": 3
-        }
-      ],
       "path": [
         "contentByContentType"
       ],

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/Auth/ContentByGuid/Snaps/ContentByGuid_Snaps_test-3.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/Auth/ContentByGuid/Snaps/ContentByGuid_Snaps_test-3.snap
@@ -221,7 +221,7 @@
         },
         "colorPicker": {
           "value": {
-            "color": "bf9000",
+            "value": "bf9000",
             "label": "bf9000"
           },
           "model": "DefaultProperty",

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/Auth/ContentByGuid/Snaps/ContentByGuid_Snaps_test-4.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/Auth/ContentByGuid/Snaps/ContentByGuid_Snaps_test-4.snap
@@ -221,7 +221,7 @@
         },
         "colorPicker": {
           "value": {
-            "color": "bf9000",
+            "value": "bf9000",
             "label": "bf9000"
           },
           "model": "DefaultProperty",

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/Auth/ContentByGuid/Snaps/ContentByGuid_Snaps_test-5.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/Auth/ContentByGuid/Snaps/ContentByGuid_Snaps_test-5.snap
@@ -2,12 +2,6 @@
   "errors": [
     {
       "message": "The current user is not authorized to access this resource.",
-      "locations": [
-        {
-          "line": 9,
-          "column": 3
-        }
-      ],
       "path": [
         "contentByGuid"
       ],

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/Auth/ContentById/Snaps/ContentById_Snaps_test-3.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/Auth/ContentById/Snaps/ContentById_Snaps_test-3.snap
@@ -221,7 +221,7 @@
         },
         "colorPicker": {
           "value": {
-            "color": "bf9000",
+            "value": "bf9000",
             "label": "bf9000"
           },
           "model": "DefaultProperty",

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/Auth/ContentById/Snaps/ContentById_Snaps_test-4.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/Auth/ContentById/Snaps/ContentById_Snaps_test-4.snap
@@ -221,7 +221,7 @@
         },
         "colorPicker": {
           "value": {
-            "color": "bf9000",
+            "value": "bf9000",
             "label": "bf9000"
           },
           "model": "DefaultProperty",

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/Auth/ContentById/Snaps/ContentById_Snaps_test-5.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/Auth/ContentById/Snaps/ContentById_Snaps_test-5.snap
@@ -2,12 +2,6 @@
   "errors": [
     {
       "message": "The current user is not authorized to access this resource.",
-      "locations": [
-        {
-          "line": 9,
-          "column": 3
-        }
-      ],
       "path": [
         "contentById"
       ],

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/Auth/ContentByRoute/Snaps/ContentByRoute_Snaps_test-1.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/Auth/ContentByRoute/Snaps/ContentByRoute_Snaps_test-1.snap
@@ -2,12 +2,6 @@
   "errors": [
     {
       "message": "The current user is not authorized to access this resource.",
-      "locations": [
-        {
-          "line": 353,
-          "column": 7
-        }
-      ],
       "path": [
         "contentByRoute",
         "properties",
@@ -237,7 +231,7 @@
         },
         "colorPicker": {
           "value": {
-            "color": "bf9000",
+            "value": "bf9000",
             "label": "bf9000"
           },
           "model": "DefaultProperty",

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/Auth/ContentByRoute/Snaps/ContentByRoute_Snaps_test-2.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/Auth/ContentByRoute/Snaps/ContentByRoute_Snaps_test-2.snap
@@ -2,12 +2,6 @@
   "errors": [
     {
       "message": "The current user is not authorized to access this resource.",
-      "locations": [
-        {
-          "line": 353,
-          "column": 7
-        }
-      ],
       "path": [
         "contentByRoute",
         "properties",
@@ -237,7 +231,7 @@
         },
         "colorPicker": {
           "value": {
-            "color": "bf9000",
+            "value": "bf9000",
             "label": "bf9000"
           },
           "model": "DefaultProperty",

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/Auth/ContentByRoute/Snaps/ContentByRoute_Snaps_test-3.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/Auth/ContentByRoute/Snaps/ContentByRoute_Snaps_test-3.snap
@@ -221,7 +221,7 @@
         },
         "colorPicker": {
           "value": {
-            "color": "bf9000",
+            "value": "bf9000",
             "label": "bf9000"
           },
           "model": "DefaultProperty",

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/Auth/ContentByRoute/Snaps/ContentByRoute_Snaps_test-4.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/Auth/ContentByRoute/Snaps/ContentByRoute_Snaps_test-4.snap
@@ -221,7 +221,7 @@
         },
         "colorPicker": {
           "value": {
-            "color": "bf9000",
+            "value": "bf9000",
             "label": "bf9000"
           },
           "model": "DefaultProperty",

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/Auth/ContentByRoute/Snaps/ContentByRoute_Snaps_test-5.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/Auth/ContentByRoute/Snaps/ContentByRoute_Snaps_test-5.snap
@@ -2,12 +2,6 @@
   "errors": [
     {
       "message": "The current user is not authorized to access this resource.",
-      "locations": [
-        {
-          "line": 9,
-          "column": 3
-        }
-      ],
       "path": [
         "contentByRoute"
       ],

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/Auth/ContentByTag/Snaps/ContentByTag_Snaps_test-3.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/Auth/ContentByTag/Snaps/ContentByTag_Snaps_test-3.snap
@@ -350,7 +350,7 @@
                   "contentProperties": {
                     "colorPicker": {
                       "value": {
-                        "color": "f44336",
+                        "value": "f44336",
                         "label": "f44336"
                       },
                       "model": "DefaultProperty",
@@ -530,7 +530,7 @@
             },
             "colorPickerCulture": {
               "value": {
-                "color": "f44336",
+                "value": "f44336",
                 "label": "f44336"
               },
               "model": "DefaultProperty",
@@ -976,7 +976,7 @@
                   "contentProperties": {
                     "colorPicker": {
                       "value": {
-                        "color": "f44336",
+                        "value": "f44336",
                         "label": "f44336"
                       },
                       "model": "DefaultProperty",
@@ -1156,7 +1156,7 @@
             },
             "colorPickerCulture": {
               "value": {
-                "color": "f44336",
+                "value": "f44336",
                 "label": "f44336"
               },
               "model": "DefaultProperty",

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/Auth/ContentByTag/Snaps/ContentByTag_Snaps_test-4.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/Auth/ContentByTag/Snaps/ContentByTag_Snaps_test-4.snap
@@ -350,7 +350,7 @@
                   "contentProperties": {
                     "colorPicker": {
                       "value": {
-                        "color": "f44336",
+                        "value": "f44336",
                         "label": "f44336"
                       },
                       "model": "DefaultProperty",
@@ -530,7 +530,7 @@
             },
             "colorPickerCulture": {
               "value": {
-                "color": "f44336",
+                "value": "f44336",
                 "label": "f44336"
               },
               "model": "DefaultProperty",
@@ -976,7 +976,7 @@
                   "contentProperties": {
                     "colorPicker": {
                       "value": {
-                        "color": "f44336",
+                        "value": "f44336",
                         "label": "f44336"
                       },
                       "model": "DefaultProperty",
@@ -1156,7 +1156,7 @@
             },
             "colorPickerCulture": {
               "value": {
-                "color": "f44336",
+                "value": "f44336",
                 "label": "f44336"
               },
               "model": "DefaultProperty",

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/Auth/ContentByTag/Snaps/ContentByTag_Snaps_test-5.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/Auth/ContentByTag/Snaps/ContentByTag_Snaps_test-5.snap
@@ -2,12 +2,6 @@
   "errors": [
     {
       "message": "The current user is not authorized to access this resource.",
-      "locations": [
-        {
-          "line": 10,
-          "column": 3
-        }
-      ],
       "path": [
         "contentByTag"
       ],

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/Auth/FindMembersByDisplayName/Snaps/FindMembersByDisplayName_Snaps_test-3.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/Auth/FindMembersByDisplayName/Snaps/FindMembersByDisplayName_Snaps_test-3.snap
@@ -2,12 +2,6 @@
   "errors": [
     {
       "message": "The current user is not authorized to access this resource.",
-      "locations": [
-        {
-          "line": 7,
-          "column": 3
-        }
-      ],
       "path": [
         "findMembersByDisplayName"
       ],

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/Auth/FindMembersByEmail/Snaps/FindMembersByEmail_Snaps_test-3.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/Auth/FindMembersByEmail/Snaps/FindMembersByEmail_Snaps_test-3.snap
@@ -2,12 +2,6 @@
   "errors": [
     {
       "message": "The current user is not authorized to access this resource.",
-      "locations": [
-        {
-          "line": 7,
-          "column": 3
-        }
-      ],
       "path": [
         "findMembersByEmail"
       ],

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/Auth/FindMembersByRole/Snaps/FindMembersByRole_Snaps_test-3.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/Auth/FindMembersByRole/Snaps/FindMembersByRole_Snaps_test-3.snap
@@ -2,12 +2,6 @@
   "errors": [
     {
       "message": "The current user is not authorized to access this resource.",
-      "locations": [
-        {
-          "line": 8,
-          "column": 3
-        }
-      ],
       "path": [
         "findMembersByRole"
       ],

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/Auth/FindMembersByUsername/Snaps/FindMembersByUsername_Snaps_test-3.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/Auth/FindMembersByUsername/Snaps/FindMembersByUsername_Snaps_test-3.snap
@@ -2,12 +2,6 @@
   "errors": [
     {
       "message": "The current user is not authorized to access this resource.",
-      "locations": [
-        {
-          "line": 7,
-          "column": 3
-        }
-      ],
       "path": [
         "findMembersByUsername"
       ],

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/Auth/MediaAtRoot/Snaps/MediaAtRoot_Snaps_test-3.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/Auth/MediaAtRoot/Snaps/MediaAtRoot_Snaps_test-3.snap
@@ -2,12 +2,6 @@
   "errors": [
     {
       "message": "The current user is not authorized to access this resource.",
-      "locations": [
-        {
-          "line": 5,
-          "column": 3
-        }
-      ],
       "path": [
         "mediaAtRoot"
       ],

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/Auth/MediaByContentType/Snaps/MediaByContentType_Snaps_test-3.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/Auth/MediaByContentType/Snaps/MediaByContentType_Snaps_test-3.snap
@@ -2,12 +2,6 @@
   "errors": [
     {
       "message": "The current user is not authorized to access this resource.",
-      "locations": [
-        {
-          "line": 6,
-          "column": 3
-        }
-      ],
       "path": [
         "mediaByContentType"
       ],

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/Auth/MediaByGuid/Snaps/MediaByGuid_Snaps_test-3.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/Auth/MediaByGuid/Snaps/MediaByGuid_Snaps_test-3.snap
@@ -2,12 +2,6 @@
   "errors": [
     {
       "message": "The current user is not authorized to access this resource.",
-      "locations": [
-        {
-          "line": 2,
-          "column": 3
-        }
-      ],
       "path": [
         "mediaByGuid"
       ],

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/Auth/MediaById/Snaps/MediaById_Snaps_test-3.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/Auth/MediaById/Snaps/MediaById_Snaps_test-3.snap
@@ -2,12 +2,6 @@
   "errors": [
     {
       "message": "The current user is not authorized to access this resource.",
-      "locations": [
-        {
-          "line": 2,
-          "column": 3
-        }
-      ],
       "path": [
         "mediaById"
       ],

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/Auth/MemberByEmail/Snaps/MemberByEmail_Snaps_test-3.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/Auth/MemberByEmail/Snaps/MemberByEmail_Snaps_test-3.snap
@@ -2,12 +2,6 @@
   "errors": [
     {
       "message": "The current user is not authorized to access this resource.",
-      "locations": [
-        {
-          "line": 4,
-          "column": 3
-        }
-      ],
       "path": [
         "memberByEmail"
       ],

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/Auth/MemberByGuid/Snaps/MemberByGuid_Snaps_test-3.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/Auth/MemberByGuid/Snaps/MemberByGuid_Snaps_test-3.snap
@@ -2,12 +2,6 @@
   "errors": [
     {
       "message": "The current user is not authorized to access this resource.",
-      "locations": [
-        {
-          "line": 4,
-          "column": 3
-        }
-      ],
       "path": [
         "memberByGuid"
       ],

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/Auth/MemberById/Snaps/MemberById_Snaps_test-3.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/Auth/MemberById/Snaps/MemberById_Snaps_test-3.snap
@@ -2,12 +2,6 @@
   "errors": [
     {
       "message": "The current user is not authorized to access this resource.",
-      "locations": [
-        {
-          "line": 4,
-          "column": 3
-        }
-      ],
       "path": [
         "memberById"
       ],

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/Auth/MemberByUsername/Snaps/MemberByUsername_Snaps_test-3.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/Auth/MemberByUsername/Snaps/MemberByUsername_Snaps_test-3.snap
@@ -2,12 +2,6 @@
   "errors": [
     {
       "message": "The current user is not authorized to access this resource.",
-      "locations": [
-        {
-          "line": 4,
-          "column": 3
-        }
-      ],
       "path": [
         "memberByUsername"
       ],

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/Auth/Schema/Schema.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/Auth/Schema/Schema.snap
@@ -3,6 +3,1077 @@ schema {
   mutation: Mutation
 }
 
+"The base query object"
+type Query {
+  "Utility query. Gets a which claims are used by the registered queries."
+  utility_GetClaimGroups: [ClaimGroup!]!
+  "Gets a content item by a route."
+  contentByRoute(
+    "The route to fetch. Example '/da/frontpage/'."
+    route: String!
+    "The context of the request."
+    inContext: QueryContextInput
+  ): ContentItem
+  "Gets all the content items by content type."
+  contentByContentType(
+    "The contentType to fetch."
+    contentType: String!
+    "How many items to include in a page. Defaults to 10."
+    pageSize: Int! = 10
+    "The page number to fetch. Defaults to 1."
+    page: Int! = 1
+    "The context of the request."
+    inContext: QueryContextInput
+  ): PaginationOfContentItem!
+  "Gets all the content items at root level."
+  contentAtRoot(
+    "How many items to include in a page. Defaults to 10."
+    pageSize: Int! = 10
+    "The page number to fetch. Defaults to 1."
+    page: Int! = 1
+    "The context of the request."
+    inContext: QueryContextInput
+  ): PaginationOfContentItem!
+  "Gets a content item by id."
+  contentById(
+    "The id to fetch."
+    id: Int!
+    "The context of the request."
+    inContext: QueryContextInput
+  ): ContentItem
+  "Gets a content item by Guid."
+  contentByGuid(
+    "The id to fetch."
+    id: UUID!
+    "The context of the request."
+    inContext: QueryContextInput
+  ): ContentItem
+  "Gets content items by tag."
+  contentByTag(
+    "The tag to fetch."
+    tag: String!
+    "The tag group to fetch."
+    tagGroup: String
+    "How many items to include in a page. Defaults to 10."
+    pageSize: Int! = 10
+    "The page number to fetch. Defaults to 1."
+    page: Int! = 1
+    "The context of the request."
+    inContext: QueryContextInput
+  ): PaginationOfContentItem!
+  "Gets all the media items by content type."
+  mediaByContentType(
+    "The content type to fetch."
+    contentType: String!
+    "How many items to include in a page. Defaults to 10."
+    pageSize: Int! = 10
+    "The page number to fetch. Defaults to 1."
+    page: Int! = 1
+  ): PaginationOfMediaItem!
+  "Gets all the media items at root level."
+  mediaAtRoot(
+    "How many items to include in a page. Defaults to 10."
+    pageSize: Int! = 10
+    "The page number to fetch. Defaults to 1."
+    page: Int! = 1
+  ): PaginationOfMediaItem!
+  "Gets a Media item by id."
+  mediaById("The id to fetch." id: Int!): MediaItem
+  "Gets a Media item by Guid."
+  mediaByGuid("The Guid to fetch." id: UUID!): MediaItem
+  "Finds members by display name."
+  findMembersByDisplayName(
+    "The display name (may be partial)."
+    displayName: String!
+    "Determines how to match a string property value."
+    matchType: StringPropertyMatchType!
+    "The page number to fetch. Defaults to 1."
+    page: Int! = 1
+    "How many items to include in a page. Defaults to 10."
+    pageSize: Int! = 10
+  ): [MemberItem]!
+  "Finds members by email."
+  findMembersByEmail(
+    "The email (may be partial)."
+    email: String!
+    "Determines how to match a string property value."
+    matchType: StringPropertyMatchType!
+    "The page number to fetch. Defaults to 1."
+    page: Int! = 1
+    "How many items to include in a page. Defaults to 10."
+    pageSize: Int! = 10
+  ): [MemberItem]!
+  "Finds members by role."
+  findMembersByRole(
+    "The role name."
+    roleName: String!
+    "The username to match."
+    usernameToMatch: String!
+    "Determines how to match a string property value."
+    matchType: StringPropertyMatchType!
+    "How many items to include in a page. Defaults to 10."
+    pageSize: Int! = 10
+    "The page number to fetch. Defaults to 1."
+    page: Int! = 1
+  ): PaginationOfMemberItem!
+  "Finds members by username."
+  findMembersByUsername(
+    "The username (may be partial)."
+    username: String!
+    "Determines how to match a string property value."
+    matchType: StringPropertyMatchType!
+    "The page number to fetch. Defaults to 1."
+    page: Int! = 1
+    "How many items to include in a page. Defaults to 10."
+    pageSize: Int! = 10
+  ): [MemberItem]!
+  "Gets a member by email."
+  memberByEmail("The email to fetch." email: String!): MemberItem
+  "Gets a member by Guid."
+  memberByGuid("The id to fetch." id: UUID!): MemberItem
+  "Gets a member by id."
+  memberById("The id to fetch." id: Int!): MemberItem
+  "Gets a member by username."
+  memberByUsername("The username to fetch." username: String!): MemberItem
+}
+
+"The base mutation object"
+type Mutation {
+  "Creates a JWT token to be used for other queries."
+  createToken("The claims of the token." claims: [TokenClaimInput!]!): JwtToken!
+}
+
+"Represents a block grid property value."
+type BlockGrid implements PropertyValue {
+  "Gets the blocks of a block grid model."
+  blocks: [BlockGridItem!]
+  "Gets the number of columns defined for the grid."
+  gridColumns: Int
+  "The model of the property value"
+  model: String!
+}
+
+"Represents a block grid area."
+type BlockGridArea {
+  "Gets the blocks of the block grid area."
+  blocks: [BlockGridItem!]
+  "Gets the alias of the block grid area."
+  alias: String!
+  "Gets the row dimensions of the block."
+  rowSpan: Int!
+  "Gets the column dimensions of the block."
+  columnSpan: Int!
+}
+
+type BlockGridEditor implements IBlockGridEditor {
+  blockGrid: BlockGrid
+}
+
+type BlockGridEditor1 implements IBlockGridEditor1 {
+  blockGrid: BlockGrid
+}
+
+"Represents a block grid item."
+type BlockGridItem {
+  "Gets the content properties of the block grid item."
+  contentProperties: TypedBlockGridContentProperties!
+  "Gets the setting properties of the block grid item."
+  settingsProperties: TypedBlockGridSettingsProperties!
+  "Gets the areas of the block grid item."
+  areas: [BlockGridArea!]!
+  "Gets the alias of the content block grid item."
+  contentAlias: String
+  "Gets the alias of the settings block grid item."
+  settingsAlias: String
+  "Gets the row dimensions of the block."
+  rowSpan: Int!
+  "Gets the column dimensions of the block."
+  columnSpan: Int!
+}
+
+"Represents a block list model."
+type BlockList implements PropertyValue {
+  "Gets the blocks of a block list model."
+  blocks: [BlockListItem!]
+  "The model of the property value"
+  model: String!
+}
+
+type BlockListEditor implements IBlockListEditor {
+  blockList: BlockList
+}
+
+type BlockListEditorCulture implements IBlockListEditorCulture {
+  blockListCulture: BlockList
+}
+
+"Represents a block list item."
+type BlockListItem {
+  "Gets the content properties of the block list item."
+  contentProperties: TypedBlockListContentProperties!
+  "Gets the setting properties of the block list item."
+  settingsProperties: TypedBlockListSettingsProperties!
+  "Gets the alias of the content block list item."
+  contentAlias: String
+  "Gets the alias of the settings block list item."
+  settingsAlias: String
+}
+
+type CheckboxListEditor implements ICheckboxListEditor {
+  checkboxList: DefaultProperty
+}
+
+type CheckboxListEditorCulture implements ICheckboxListEditorCulture {
+  checkboxListCulture: DefaultProperty
+}
+
+"A group of claims."
+type ClaimGroup {
+  "The name of the group."
+  groupName: String!
+  "The claim values in the group."
+  claimValues: [ClaimValue!]!
+}
+
+type ClaimValue {
+  "The name of the claim."
+  name: String!
+  "The available values of the claim."
+  values: [String!]!
+}
+
+type ColorPickerEditor implements IColorPickerEditor {
+  colorPicker: DefaultProperty
+}
+
+type ColorPickerEditorCulture implements IColorPickerEditorCulture {
+  colorPickerCulture: DefaultProperty
+}
+
+type ContentItem {
+  "Gets the url segment of the content item."
+  urlSegment: String
+  "Gets the url of a content item."
+  url(urlMode: UrlMode!): String
+  "Gets the name of a content item."
+  name: String
+  "Gets the parent of the content item."
+  parent: ContentItem
+  "Gets the properties of the content item."
+  properties: TypedProperties!
+  "Gets the id of a content item."
+  id: Int
+  "Gets the key of a content item."
+  key: UUID
+  "Gets the identifier of the template to use to render the content item."
+  templateId: Int
+  "Gets the date the content item was last updated."
+  updateDate: DateTime
+  statusCode: Int!
+  "Gets the redirect information for the content item."
+  redirect: RedirectInfo
+}
+
+"Represents a content picker value."
+type ContentPicker implements PropertyValue {
+  "Gets the content items of a picker."
+  items: [ContentPickerItem!]
+  "The model of the property value"
+  model: String!
+}
+
+type ContentPickerEditor implements IContentPickerEditor {
+  contentPicker: ContentPicker
+}
+
+type ContentPickerEditorCulture implements IContentPickerEditorCulture {
+  contentPickerCulture: ContentPicker
+}
+
+"Represents a content picker item."
+type ContentPickerItem {
+  "Gets the url of a content item."
+  url(urlMode: UrlMode!): String!
+  "Gets the properties of the content item."
+  properties: TypedProperties!
+  "Gets the url segment of the content item."
+  urlSegment: String
+  "Gets the name of a content item."
+  name: String
+  "Gets the id of a content item."
+  id: Int!
+  "Gets the key of a content item."
+  key: UUID!
+}
+
+type CustomMediaType implements ICustomMediaType {
+  approvedColorEditor: DefaultProperty
+  article: DefaultProperty
+  audio: DefaultProperty
+  blockList: BlockList
+  checkboxList: DefaultProperty
+  contentPicker: ContentPicker
+  datePicker: DateTimePicker
+  datePickerWithTime: DateTimePicker
+  decimal: DefaultProperty
+  dropDown: DefaultProperty
+  dropdownMultiple: DefaultProperty
+  emailAddress: DefaultProperty
+  eyeDropperColorPicker: DefaultProperty
+  file: DefaultProperty
+  imageCropper: DefaultProperty
+  imageMediaPicker: MediaPicker
+  markdownEditor: RichText
+  memberGroupPicker: DefaultProperty
+  memberPicker: MemberPicker
+  multinodeTreepicker: ContentPicker
+  multiUrlPicker: MultiUrlPicker
+  numeric: DefaultProperty
+  radiobox: DefaultProperty
+  repeatableTextStrings: DefaultProperty
+  richText: RichText
+  slider: DefaultProperty
+  sVG: DefaultProperty
+  tags: DefaultProperty
+  textarea: DefaultProperty
+  textstring: DefaultProperty
+  toggle: DefaultProperty
+  userPicker: DefaultProperty
+  video: DefaultProperty
+}
+
+type DatePickerEditor implements IDatePickerEditor {
+  datePicker: DateTimePicker
+  datePickerWithTime: DateTimePicker
+}
+
+type DatePickerEditorCulture implements IDatePickerEditorCulture {
+  datePickerCulture: DateTimePicker
+  datePickerWithTimeCulture: DateTimePicker
+}
+
+"Represents a date time property value."
+type DateTimePicker implements PropertyValue {
+  "Gets the value of the property."
+  value: DateTime
+  "The model of the property value"
+  model: String!
+}
+
+type DecimalEditor implements IDecimalEditor {
+  decimal: DefaultProperty
+}
+
+type DecimalEditorCulture implements IDecimalEditorCulture {
+  decimalCulture: DefaultProperty
+}
+
+type Default implements IBlockGridEditor &
+  IBlockListEditor &
+  ICheckboxListEditor &
+  IColorPickerEditor &
+  IContentPickerEditor &
+  IDatePickerEditor &
+  IDecimalEditor &
+  IDropdownEditor &
+  IEmailAddressEditor &
+  IEyeDropperColorPickerEditor &
+  IFileUpload &
+  IImageCropperEditor &
+  IMarkdownEditor &
+  IMediaPickerEditor &
+  IMemberGroupPickerEditor &
+  IMemberPickerEditor &
+  IMultinodeTreepickerEditor &
+  IMultiUrlPickerEditor &
+  INumericEditor &
+  IRadioboxEditor &
+  IRepeatableTextstringsEditor &
+  IRichtextEditor &
+  ISliderEditor &
+  ITagsEditor &
+  ITextareaEditor &
+  ITextboxEditor &
+  IToggleEditor &
+  IUserPickerEditor &
+  IDefault {
+  blockGrid: BlockGrid
+  blockList: BlockList
+  checkboxList: DefaultProperty
+  colorPicker: DefaultProperty
+  contentPicker: ContentPicker
+  datePicker: DateTimePicker
+  datePickerWithTime: DateTimePicker
+  decimal: DefaultProperty
+  dropdown: DefaultProperty
+  emailAddress: DefaultProperty
+  eyeDropperColorPicker: DefaultProperty
+  article: DefaultProperty
+  audio: DefaultProperty
+  file: DefaultProperty
+  svg: DefaultProperty
+  video: DefaultProperty
+  imageCropper: DefaultProperty
+  markdown: RichText
+  imageMediaPicker: MediaPicker
+  mediaPicker: MediaPicker
+  multipleImageMediaPicker: MediaPicker
+  multipleMediaPicker: MediaPicker
+  memberGroupPicker: DefaultProperty
+  memberPicker: MemberPicker
+  multinodeTreepicker: ContentPicker
+  multiUrlPicker: MultiUrlPicker
+  numeric: DefaultProperty
+  radiobox: DefaultProperty
+  repeatableTextstrings: DefaultProperty
+  richtext: RichText
+  slider: DefaultProperty
+  tags: DefaultProperty
+  textarea: DefaultProperty
+  textstring: DefaultProperty
+  trueOrFalse: DefaultProperty
+  userPicker: DefaultProperty
+}
+
+type DefaultCulture implements IBlockListEditor &
+  IBlockListEditorCulture &
+  ICheckboxListEditor &
+  ICheckboxListEditorCulture &
+  IColorPickerEditor &
+  IColorPickerEditorCulture &
+  IContentPickerEditor &
+  IContentPickerEditorCulture &
+  IDatePickerEditor &
+  IDatePickerEditorCulture &
+  IDecimalEditor &
+  IDecimalEditorCulture &
+  IDropdownEditor &
+  IDropdownEditorCulture &
+  IEmailAddressEditor &
+  IEmailAddressEditorCulture &
+  IEyeDropperColorPickerEditor &
+  IEyeDropperColorPickerEditorCulture &
+  IFileUpload &
+  IFileUploadCulture &
+  IImageCropperEditor &
+  IImageCropperEditorCulture &
+  IMarkdownEditor &
+  IMarkdownEditorCulture &
+  IMediaPickerEditor &
+  IMediaPickerEditorCulture &
+  IMemberGroupPickerEditor &
+  IMemberGroupPickerEditorCulture &
+  IMemberPickerEditor &
+  IMemberPickerEditorCulture &
+  IMultinodeTreepickerEditor &
+  IMultinodeTreepickerEditorCulture &
+  IMultiUrlPickerEditor &
+  IMultiUrlPickerEditorCulture &
+  INumericEditor &
+  INumericEditorCulture &
+  IRadioboxEditor &
+  IRadioboxEditorCulture &
+  IRepeatableTextstringsEditor &
+  IRepeatableTextstringsEditorCulture &
+  IRichtextEditor &
+  IRichtextEditorCulture &
+  ISliderEditor &
+  ISliderEditorCulture &
+  ITagsEditor &
+  ITagsEditorCulture &
+  ITextareaEditor &
+  ITextareaEditorCulture &
+  ITextboxEditor &
+  ITextboxEditorCulture &
+  IToggleEditor &
+  IToggleEditorCulture &
+  IUserPickerEditor &
+  IUserPickerEditorCulture &
+  IDefaultCulture {
+  blockList: BlockList
+  blockListCulture: BlockList
+  checkboxList: DefaultProperty
+  checkboxListCulture: DefaultProperty
+  colorPicker: DefaultProperty
+  colorPickerCulture: DefaultProperty
+  contentPicker: ContentPicker
+  contentPickerCulture: ContentPicker
+  datePicker: DateTimePicker
+  datePickerWithTime: DateTimePicker
+  datePickerCulture: DateTimePicker
+  datePickerWithTimeCulture: DateTimePicker
+  decimal: DefaultProperty
+  decimalCulture: DefaultProperty
+  dropdown: DefaultProperty
+  dropdownCulture: DefaultProperty
+  emailAddress: DefaultProperty
+  emailAddressCulture: DefaultProperty
+  eyeDropperColorPicker: DefaultProperty
+  eyeDropperColorPickerCulture: DefaultProperty
+  article: DefaultProperty
+  audio: DefaultProperty
+  file: DefaultProperty
+  svg: DefaultProperty
+  video: DefaultProperty
+  articleCulture: DefaultProperty
+  audioCulture: DefaultProperty
+  fileCulture: DefaultProperty
+  svgCulture: DefaultProperty
+  videoCulture: DefaultProperty
+  imageCropper: DefaultProperty
+  imageCropperCulture: DefaultProperty
+  markdown: RichText
+  markdownCulture: RichText
+  imageMediaPicker: MediaPicker
+  mediaPicker: MediaPicker
+  multipleImageMediaPicker: MediaPicker
+  multipleMediaPicker: MediaPicker
+  imageMediaPickerCulture: MediaPicker
+  mediaPickerCulture: MediaPicker
+  multipleImageMediaPickerCulture: MediaPicker
+  multipleMediaPickerCulture: MediaPicker
+  memberGroupPicker: DefaultProperty
+  memberGroupPickerCulture: DefaultProperty
+  memberPicker: MemberPicker
+  memberPickerCulture: MemberPicker
+  multinodeTreepicker: ContentPicker
+  multinodeTreepickerCulture: ContentPicker
+  multiUrlPicker: MultiUrlPicker
+  multiUrlPickerCulture: MultiUrlPicker
+  numeric: DefaultProperty
+  numericCulture: DefaultProperty
+  radiobox: DefaultProperty
+  radioboxCulture: DefaultProperty
+  repeatableTextstrings: DefaultProperty
+  repeatableTextstringsCulture: DefaultProperty
+  richtext: RichText
+  richtextCulture: RichText
+  slider: DefaultProperty
+  sliderCulture: DefaultProperty
+  tags: DefaultProperty
+  tagsCulture: DefaultProperty
+  textarea: DefaultProperty
+  textareaCulture: DefaultProperty
+  textstring: DefaultProperty
+  textstringCulture: DefaultProperty
+  trueOrFalse: DefaultProperty
+  trueOrFalseCulture: DefaultProperty
+  userPicker: DefaultProperty
+  userPickerCulture: DefaultProperty
+}
+
+"A catch all property value that simply returns the value of the property. This is all that is needed for simple properties that doesn't need any special handling or formatting."
+type DefaultProperty implements PropertyValue {
+  "Gets the value of the property."
+  value: Any
+  "The model of the property value"
+  model: String!
+}
+
+type DropdownEditor implements IDropdownEditor {
+  dropdown: DefaultProperty
+}
+
+type DropdownEditorCulture implements IDropdownEditorCulture {
+  dropdownCulture: DefaultProperty
+}
+
+type EmailAddressEditor implements IEmailAddressEditor {
+  emailAddress: DefaultProperty
+}
+
+type EmailAddressEditorCulture implements IEmailAddressEditorCulture {
+  emailAddressCulture: DefaultProperty
+}
+
+"Represents a content type that doesn't have any properties and therefore needs a placeholder"
+type EmptyPropertyType {
+  "Placeholder field. Will never hold a value."
+  Empty_Field: String!
+}
+
+type EyeDropperColorPickerEditor implements IEyeDropperColorPickerEditor {
+  eyeDropperColorPicker: DefaultProperty
+}
+
+type EyeDropperColorPickerEditorCulture implements IEyeDropperColorPickerEditorCulture {
+  eyeDropperColorPickerCulture: DefaultProperty
+}
+
+type File implements IFile {
+  umbracoFile: DefaultProperty
+  umbracoExtension: Label
+  "in bytes"
+  umbracoBytes: Label
+}
+
+type FileUpload implements IFileUpload {
+  article: DefaultProperty
+  audio: DefaultProperty
+  file: DefaultProperty
+  svg: DefaultProperty
+  video: DefaultProperty
+}
+
+type FileUploadCulture implements IFileUploadCulture {
+  articleCulture: DefaultProperty
+  audioCulture: DefaultProperty
+  fileCulture: DefaultProperty
+  svgCulture: DefaultProperty
+  videoCulture: DefaultProperty
+}
+
+"Represents focal point coordinates for an image."
+type FocalPoint {
+  "The left coordinate (0.0 to 1.0)"
+  left: Decimal!
+  "The top coordinate (0.0 to 1.0)"
+  top: Decimal!
+}
+
+type Image implements IImage {
+  umbracoFile: DefaultProperty
+  "in pixels"
+  umbracoWidth: Label
+  "in pixels"
+  umbracoHeight: Label
+  "in bytes"
+  umbracoBytes: Label
+  umbracoExtension: Label
+}
+
+type ImageCropperEditor implements IImageCropperEditor {
+  imageCropper: DefaultProperty
+}
+
+type ImageCropperEditorCulture implements IImageCropperEditorCulture {
+  imageCropperCulture: DefaultProperty
+}
+
+"A JWT token."
+type JwtToken {
+  "The JWT token."
+  token: String!
+  "The expiration time of the token in Unix timestamp."
+  expires: Long!
+  "The prefix used when using the token."
+  prefix: String!
+  "The header used when using the token."
+  header: String!
+}
+
+type Label implements PropertyValue {
+  "Gets the value of the property."
+  value: Any
+  "The model of the property value"
+  model: String!
+}
+
+type LabelEditor implements ILabelEditor {
+  bigint: Label
+  datetime: Label
+  decimal: Label
+  integer: Label
+  string: Label
+  time: Label
+}
+
+type LabelEditorCulture implements ILabelEditorCulture {
+  bigintCulture: Label
+  datetimeCulture: Label
+  decimalCulture: Label
+  integerCulture: Label
+  stringCulture: Label
+  timeCulture: Label
+}
+
+type MarkdownEditor implements IMarkdownEditor {
+  markdown: RichText
+}
+
+type MarkdownEditorCulture implements IMarkdownEditorCulture {
+  markdownCulture: RichText
+}
+
+type MediaItem {
+  "Gets the url of a media item."
+  url(urlMode: UrlMode!, propertyAlias: String! = "umbracoFile"): String
+  "Gets the parent of the media item."
+  parent: MediaItem
+  "Gets the properties of the media item."
+  properties: TypedProperties!
+  "Gets the url segment of the media item."
+  urlSegment: String
+  "Gets the name of a media item."
+  name: String
+  "Gets the id of a media item."
+  id: Int
+  "Gets the key of a media item."
+  key: UUID
+  "Gets the identifier of the template to use to render the media item."
+  templateId: Int
+  "Gets the date the media item was last updated."
+  updateDate: DateTime
+}
+
+"Represents a media picker item."
+type MediaPicker implements PropertyValue {
+  "Gets the media items of a picker."
+  mediaItems: [MediaPickerItem!]!
+  "The model of the property value"
+  model: String!
+}
+
+type MediaPickerEditor implements IMediaPickerEditor {
+  imageMediaPicker: MediaPicker
+  mediaPicker: MediaPicker
+  multipleImageMediaPicker: MediaPicker
+  multipleMediaPicker: MediaPicker
+}
+
+type MediaPickerEditorCulture implements IMediaPickerEditorCulture {
+  imageMediaPickerCulture: MediaPicker
+  mediaPickerCulture: MediaPicker
+  multipleImageMediaPickerCulture: MediaPicker
+  multipleMediaPickerCulture: MediaPicker
+}
+
+"Represents a media item."
+type MediaPickerItem {
+  "Gets the url of a media item."
+  url(urlMode: UrlMode!): String!
+  "Gets the focal point of an image."
+  focalPoint: FocalPoint
+  "Gets the properties of the media item."
+  properties: TypedProperties!
+  "Gets the url segment of the media item."
+  urlSegment: String
+  "Gets the name of a media item."
+  name: String
+  "Gets the id of a media item."
+  id: Int!
+  "Gets the key of a media item."
+  key: UUID!
+}
+
+type Member implements IMember {
+  umbracoMemberComments: DefaultProperty
+  umbracoMemberFailedPasswordAttempts: Label
+  umbracoMemberApproved: DefaultProperty
+  umbracoMemberLockedOut: DefaultProperty
+  umbracoMemberLastLockoutDate: Label
+  umbracoMemberLastLogin: Label
+  umbracoMemberLastPasswordChangeDate: Label
+}
+
+type MemberGroupPickerEditor implements IMemberGroupPickerEditor {
+  memberGroupPicker: DefaultProperty
+}
+
+type MemberGroupPickerEditorCulture implements IMemberGroupPickerEditorCulture {
+  memberGroupPickerCulture: DefaultProperty
+}
+
+type MemberItem {
+  "Gets the properties of the member item."
+  properties: TypedProperties!
+  "Gets the name of a member item."
+  name: String
+  "Gets the id of a member item."
+  id: Int
+  "Gets the key of a member item."
+  key: UUID
+  "Gets the identifier of the template to use to render the member item."
+  templateId: Int
+  "Gets the date the member item was last updated."
+  updateDate: DateTime
+}
+
+"Represents a member picker."
+type MemberPicker implements PropertyValue {
+  "Gets the member items of a picker. Requires the property.values.member.picker or global.member.read claim to access"
+  members: [MemberPickerItem!]!
+  "The model of the property value"
+  model: String!
+}
+
+type MemberPickerEditor implements IMemberPickerEditor {
+  memberPicker: MemberPicker
+}
+
+type MemberPickerEditorCulture implements IMemberPickerEditorCulture {
+  memberPickerCulture: MemberPicker
+}
+
+"Represents a member item."
+type MemberPickerItem {
+  "Gets the properties of the member item."
+  properties: TypedProperties!
+  "Gets the name of a member item."
+  name: String
+  "Gets the id of a member item."
+  id: Int!
+  "Gets the key of a member item."
+  key: UUID!
+}
+
+type MultinodeTreepickerEditor implements IMultinodeTreepickerEditor {
+  multinodeTreepicker: ContentPicker
+}
+
+type MultinodeTreepickerEditorCulture implements IMultinodeTreepickerEditorCulture {
+  multinodeTreepickerCulture: ContentPicker
+}
+
+"Represents a multi url picker."
+type MultiUrlPicker implements PropertyValue {
+  "Gets the links of the picker."
+  links: [MultiUrlPickerItem!]!
+  "The model of the property value"
+  model: String!
+}
+
+type MultiUrlPickerEditor implements IMultiUrlPickerEditor {
+  multiUrlPicker: MultiUrlPicker
+}
+
+type MultiUrlPickerEditorCulture implements IMultiUrlPickerEditorCulture {
+  multiUrlPickerCulture: MultiUrlPicker
+}
+
+"Represents a content item."
+type MultiUrlPickerItem {
+  "Gets the url of a content item. If the link isn't to a content item or media item then the UrlMode doesn't affect the url."
+  url(urlMode: UrlMode!): String!
+  "Gets the properties of the content item."
+  properties: TypedProperties!
+  "Gets the url segment of the content item."
+  urlSegment: String
+  "Gets the target of the link."
+  target: String
+  "Gets the type of the link."
+  type: LinkType!
+  "Gets the title of the link."
+  title: String
+  "Gets the name of a content item."
+  name: String
+  "Gets the id of a content item."
+  id: Int
+  "Gets the key of a content item."
+  key: UUID
+}
+
+"Represents nested content."
+type NestedContent implements PropertyValue {
+  "Gets the elements of a nested content."
+  elements: [NestedContentItem!]!
+  "The model of the property value"
+  model: String!
+}
+
+type NestedContentItem {
+  "Gets the properties of the nested content."
+  properties: TypedNestedContentProperties!
+}
+
+type NumericEditor implements INumericEditor {
+  numeric: DefaultProperty
+}
+
+type NumericEditorCulture implements INumericEditorCulture {
+  numericCulture: DefaultProperty
+}
+
+"Represents a paginated list of items."
+type PaginationOfContentItem {
+  "The page number."
+  page: Int!
+  "The page size"
+  pageSize: Int!
+  "The total number of items."
+  totalItems: Int!
+  "Whether there is a next page."
+  hasNextPage: Boolean!
+  "The items in the paginated list."
+  items: [ContentItem!]!
+}
+
+"Represents a paginated list of items."
+type PaginationOfMediaItem {
+  "The page number."
+  page: Int!
+  "The page size"
+  pageSize: Int!
+  "The total number of items."
+  totalItems: Int!
+  "Whether there is a next page."
+  hasNextPage: Boolean!
+  "The items in the paginated list."
+  items: [MediaItem!]!
+}
+
+"Represents a paginated list of items."
+type PaginationOfMemberItem {
+  "The page number."
+  page: Int!
+  "The page size"
+  pageSize: Int!
+  "The total number of items."
+  totalItems: Int!
+  "Whether there is a next page."
+  hasNextPage: Boolean!
+  "The items in the paginated list."
+  items: [MemberItem!]!
+}
+
+type RadioboxEditor implements IRadioboxEditor {
+  radiobox: DefaultProperty
+}
+
+type RadioboxEditorCulture implements IRadioboxEditorCulture {
+  radioboxCulture: DefaultProperty
+}
+
+type RedirectInfo {
+  redirectUrl: String
+  isPermanent: Boolean!
+}
+
+type RepeatableTextstringsEditor implements IRepeatableTextstringsEditor {
+  repeatableTextstrings: DefaultProperty
+}
+
+type RepeatableTextstringsEditorCulture implements IRepeatableTextstringsEditorCulture {
+  repeatableTextstringsCulture: DefaultProperty
+}
+
+"Represents a rich text editor."
+type RichText implements PropertyValue {
+  "Gets the HTML value of the rich text editor or markdown editor."
+  value: String
+  "Gets the original value of the rich text editor or markdown editor."
+  sourceValue: String
+  "The model of the property value"
+  model: String!
+}
+
+type RichtextEditor implements IRichtextEditor {
+  richtext: RichText
+}
+
+type RichtextEditorCulture implements IRichtextEditorCulture {
+  richtextCulture: RichText
+}
+
+type SiteWithCulture implements ITextboxEditor &
+  ITextboxEditorCulture &
+  ISiteWithCulture {
+  textstring: DefaultProperty
+  textstringCulture: DefaultProperty
+}
+
+type SliderEditor implements ISliderEditor {
+  slider: DefaultProperty
+}
+
+type SliderEditorCulture implements ISliderEditorCulture {
+  sliderCulture: DefaultProperty
+}
+
+type TagsEditor implements ITagsEditor {
+  tags: DefaultProperty
+}
+
+type TagsEditorCulture implements ITagsEditorCulture {
+  tagsCulture: DefaultProperty
+}
+
+type TestMember implements ITestMember {
+  blockList: BlockList
+  nestedContent: MemberPicker
+  umbracoMemberComments: DefaultProperty
+}
+
+type TextareaEditor implements ITextareaEditor {
+  textarea: DefaultProperty
+}
+
+type TextareaEditorCulture implements ITextareaEditorCulture {
+  textareaCulture: DefaultProperty
+}
+
+type TextboxEditor implements ITextboxEditor {
+  textstring: DefaultProperty
+}
+
+type TextboxEditorCulture implements ITextboxEditorCulture {
+  textstringCulture: DefaultProperty
+}
+
+type ToggleEditor implements IToggleEditor {
+  trueOrFalse: DefaultProperty
+}
+
+type ToggleEditorCulture implements IToggleEditorCulture {
+  trueOrFalseCulture: DefaultProperty
+}
+
+type UmbBlockGridDemoHeadlineBlock implements IUmbBlockGridDemoHeadlineBlock {
+  headline: DefaultProperty
+}
+
+type UmbBlockGridDemoImageBlock implements IUmbBlockGridDemoImageBlock {
+  image: MediaPicker
+}
+
+type UmbBlockGridDemoRichTextBlock implements IUmbBlockGridDemoRichTextBlock {
+  richText: RichText
+}
+
+type UmbracoMediaArticle implements IUmbracoMediaArticle {
+  umbracoFile: DefaultProperty
+  umbracoExtension: Label
+  "in bytes"
+  umbracoBytes: Label
+}
+
+type UmbracoMediaAudio implements IUmbracoMediaAudio {
+  umbracoFile: DefaultProperty
+  umbracoExtension: Label
+  "in bytes"
+  umbracoBytes: Label
+}
+
+type UmbracoMediaVectorGraphics implements IUmbracoMediaVectorGraphics {
+  umbracoFile: DefaultProperty
+  umbracoExtension: Label
+  "in bytes"
+  umbracoBytes: Label
+}
+
+type UmbracoMediaVideo implements IUmbracoMediaVideo {
+  umbracoFile: DefaultProperty
+  umbracoExtension: Label
+  "in bytes"
+  umbracoBytes: Label
+}
+
+"Represents an unsupported property value."
+type UnsupportedProperty implements PropertyValue {
+  "Gets the message of the property."
+  message: String!
+  "The model of the property value"
+  model: String!
+}
+
+type UserPickerEditor implements IUserPickerEditor {
+  userPicker: DefaultProperty
+}
+
+type UserPickerEditorCulture implements IUserPickerEditorCulture {
+  userPickerCulture: DefaultProperty
+}
+
 interface IBlockGridEditor {
   blockGrid: BlockGrid
 }
@@ -341,20 +1412,20 @@ interface IMemberPickerEditorCulture {
   memberPickerCulture: MemberPicker
 }
 
-interface IMultiUrlPickerEditor {
-  multiUrlPicker: MultiUrlPicker
-}
-
-interface IMultiUrlPickerEditorCulture {
-  multiUrlPickerCulture: MultiUrlPicker
-}
-
 interface IMultinodeTreepickerEditor {
   multinodeTreepicker: ContentPicker
 }
 
 interface IMultinodeTreepickerEditorCulture {
   multinodeTreepickerCulture: ContentPicker
+}
+
+interface IMultiUrlPickerEditor {
+  multiUrlPicker: MultiUrlPicker
+}
+
+interface IMultiUrlPickerEditorCulture {
+  multiUrlPickerCulture: MultiUrlPicker
 }
 
 interface INumericEditor {
@@ -494,918 +1565,467 @@ interface PropertyValue {
   model: String!
 }
 
-"Represents a block grid property value."
-type BlockGrid implements PropertyValue {
-  "Gets the blocks of a block grid model."
-  blocks: [BlockGridItem!]
-  "Gets the number of columns defined for the grid."
-  gridColumns: Int
-  "The model of the property value"
-  model: String!
-}
-
-"Represents a block grid area."
-type BlockGridArea {
-  "Gets the blocks of the block grid area."
-  blocks: [BlockGridItem!]
-  "Gets the alias of the block grid area."
-  alias: String!
-  "Gets the row dimensions of the block."
-  rowSpan: Int!
-  "Gets the column dimensions of the block."
-  columnSpan: Int!
-}
-
-type BlockGridEditor implements IBlockGridEditor {
-  blockGrid: BlockGrid
-}
-
-type BlockGridEditor1 implements IBlockGridEditor1 {
-  blockGrid: BlockGrid
-}
-
-"Represents a block grid item."
-type BlockGridItem {
-  "Gets the content properties of the block grid item."
-  contentProperties: TypedBlockGridContentProperties!
-  "Gets the setting properties of the block grid item."
-  settingsProperties: TypedBlockGridSettingsProperties!
-  "Gets the areas of the block grid item."
-  areas: [BlockGridArea!]!
-  "Gets the alias of the content block grid item."
-  contentAlias: String
-  "Gets the alias of the settings block grid item."
-  settingsAlias: String
-  "Gets the row dimensions of the block."
-  rowSpan: Int!
-  "Gets the column dimensions of the block."
-  columnSpan: Int!
-}
-
-"Represents a block list model."
-type BlockList implements PropertyValue {
-  "Gets the blocks of a block list model."
-  blocks: [BlockListItem!]
-  "The model of the property value"
-  model: String!
-}
-
-type BlockListEditor implements IBlockListEditor {
-  blockList: BlockList
-}
-
-type BlockListEditorCulture implements IBlockListEditorCulture {
-  blockListCulture: BlockList
-}
-
-"Represents a block list item."
-type BlockListItem {
-  "Gets the content properties of the block list item."
-  contentProperties: TypedBlockListContentProperties!
-  "Gets the setting properties of the block list item."
-  settingsProperties: TypedBlockListSettingsProperties!
-  "Gets the alias of the content block list item."
-  contentAlias: String
-  "Gets the alias of the settings block list item."
-  settingsAlias: String
-}
-
-type CheckboxListEditor implements ICheckboxListEditor {
-  checkboxList: DefaultProperty
-}
-
-type CheckboxListEditorCulture implements ICheckboxListEditorCulture {
-  checkboxListCulture: DefaultProperty
-}
-
-"A group of claims."
-type ClaimGroup {
-  "The name of the group."
-  groupName: String!
-  "The claim values in the group."
-  claimValues: [ClaimValue!]!
-}
-
-type ClaimValue {
-  "The name of the claim."
-  name: String!
-  "The available values of the claim."
-  values: [String!]!
-}
-
-type ColorPickerEditor implements IColorPickerEditor {
-  colorPicker: DefaultProperty
-}
-
-type ColorPickerEditorCulture implements IColorPickerEditorCulture {
-  colorPickerCulture: DefaultProperty
-}
-
-type ContentItem {
-  "Gets the url segment of the content item."
-  urlSegment: String
-  "Gets the url of a content item."
-  url(urlMode: UrlMode!): String
-  "Gets the name of a content item."
-  name: String
-  "Gets the parent of the content item."
-  parent: ContentItem
-  "Gets the properties of the content item."
-  properties: TypedProperties!
-  "Gets the id of a content item."
-  id: Int
-  "Gets the key of a content item."
-  key: UUID
-  "Gets the identifier of the template to use to render the content item."
-  templateId: Int
-  "Gets the date the content item was last updated."
-  updateDate: DateTime
-  statusCode: Int!
-  "Gets the redirect information for the content item."
-  redirect: RedirectInfo
-}
-
-"Represents a content picker value."
-type ContentPicker implements PropertyValue {
-  "Gets the content items of a picker."
-  items: [ContentPickerItem!]
-  "The model of the property value"
-  model: String!
-}
-
-type ContentPickerEditor implements IContentPickerEditor {
-  contentPicker: ContentPicker
-}
-
-type ContentPickerEditorCulture implements IContentPickerEditorCulture {
-  contentPickerCulture: ContentPicker
-}
-
-"Represents a content picker item."
-type ContentPickerItem {
-  "Gets the url of a content item."
-  url(urlMode: UrlMode!): String!
-  "Gets the properties of the content item."
-  properties: TypedProperties!
-  "Gets the url segment of the content item."
-  urlSegment: String
-  "Gets the name of a content item."
-  name: String
-  "Gets the id of a content item."
-  id: Int!
-  "Gets the key of a content item."
-  key: UUID!
-}
-
-type CustomMediaType implements ICustomMediaType {
-  approvedColorEditor: DefaultProperty
-  article: DefaultProperty
-  audio: DefaultProperty
-  blockList: BlockList
-  checkboxList: DefaultProperty
-  contentPicker: ContentPicker
-  datePicker: DateTimePicker
-  datePickerWithTime: DateTimePicker
-  decimal: DefaultProperty
-  dropDown: DefaultProperty
-  dropdownMultiple: DefaultProperty
-  emailAddress: DefaultProperty
-  eyeDropperColorPicker: DefaultProperty
-  file: DefaultProperty
-  imageCropper: DefaultProperty
-  imageMediaPicker: MediaPicker
-  markdownEditor: RichText
-  memberGroupPicker: DefaultProperty
-  memberPicker: MemberPicker
-  multinodeTreepicker: ContentPicker
-  multiUrlPicker: MultiUrlPicker
-  numeric: DefaultProperty
-  radiobox: DefaultProperty
-  repeatableTextStrings: DefaultProperty
-  richText: RichText
-  slider: DefaultProperty
-  sVG: DefaultProperty
-  tags: DefaultProperty
-  textarea: DefaultProperty
-  textstring: DefaultProperty
-  toggle: DefaultProperty
-  userPicker: DefaultProperty
-  video: DefaultProperty
-}
-
-type DatePickerEditor implements IDatePickerEditor {
-  datePicker: DateTimePicker
-  datePickerWithTime: DateTimePicker
-}
-
-type DatePickerEditorCulture implements IDatePickerEditorCulture {
-  datePickerCulture: DateTimePicker
-  datePickerWithTimeCulture: DateTimePicker
-}
-
-"Represents a date time property value."
-type DateTimePicker implements PropertyValue {
-  "Gets the value of the property."
-  value: DateTime
-  "The model of the property value"
-  model: String!
-}
-
-type DecimalEditor implements IDecimalEditor {
-  decimal: DefaultProperty
-}
-
-type DecimalEditorCulture implements IDecimalEditorCulture {
-  decimalCulture: DefaultProperty
-}
-
-type Default implements IBlockGridEditor & IBlockListEditor & ICheckboxListEditor & IColorPickerEditor & IContentPickerEditor & IDatePickerEditor & IDecimalEditor & IDropdownEditor & IEmailAddressEditor & IEyeDropperColorPickerEditor & IFileUpload & IImageCropperEditor & IMarkdownEditor & IMediaPickerEditor & IMemberGroupPickerEditor & IMemberPickerEditor & IMultinodeTreepickerEditor & IMultiUrlPickerEditor & INumericEditor & IRadioboxEditor & IRepeatableTextstringsEditor & IRichtextEditor & ISliderEditor & ITagsEditor & ITextareaEditor & ITextboxEditor & IToggleEditor & IUserPickerEditor & IDefault {
-  blockGrid: BlockGrid
-  blockList: BlockList
-  checkboxList: DefaultProperty
-  colorPicker: DefaultProperty
-  contentPicker: ContentPicker
-  datePicker: DateTimePicker
-  datePickerWithTime: DateTimePicker
-  decimal: DefaultProperty
-  dropdown: DefaultProperty
-  emailAddress: DefaultProperty
-  eyeDropperColorPicker: DefaultProperty
-  article: DefaultProperty
-  audio: DefaultProperty
-  file: DefaultProperty
-  svg: DefaultProperty
-  video: DefaultProperty
-  imageCropper: DefaultProperty
-  markdown: RichText
-  imageMediaPicker: MediaPicker
-  mediaPicker: MediaPicker
-  multipleImageMediaPicker: MediaPicker
-  multipleMediaPicker: MediaPicker
-  memberGroupPicker: DefaultProperty
-  memberPicker: MemberPicker
-  multinodeTreepicker: ContentPicker
-  multiUrlPicker: MultiUrlPicker
-  numeric: DefaultProperty
-  radiobox: DefaultProperty
-  repeatableTextstrings: DefaultProperty
-  richtext: RichText
-  slider: DefaultProperty
-  tags: DefaultProperty
-  textarea: DefaultProperty
-  textstring: DefaultProperty
-  trueOrFalse: DefaultProperty
-  userPicker: DefaultProperty
-}
-
-type DefaultCulture implements IBlockListEditor & IBlockListEditorCulture & ICheckboxListEditor & ICheckboxListEditorCulture & IColorPickerEditor & IColorPickerEditorCulture & IContentPickerEditor & IContentPickerEditorCulture & IDatePickerEditor & IDatePickerEditorCulture & IDecimalEditor & IDecimalEditorCulture & IDropdownEditor & IDropdownEditorCulture & IEmailAddressEditor & IEmailAddressEditorCulture & IEyeDropperColorPickerEditor & IEyeDropperColorPickerEditorCulture & IFileUpload & IFileUploadCulture & IImageCropperEditor & IImageCropperEditorCulture & IMarkdownEditor & IMarkdownEditorCulture & IMediaPickerEditor & IMediaPickerEditorCulture & IMemberGroupPickerEditor & IMemberGroupPickerEditorCulture & IMemberPickerEditor & IMemberPickerEditorCulture & IMultinodeTreepickerEditor & IMultinodeTreepickerEditorCulture & IMultiUrlPickerEditor & IMultiUrlPickerEditorCulture & INumericEditor & INumericEditorCulture & IRadioboxEditor & IRadioboxEditorCulture & IRepeatableTextstringsEditor & IRepeatableTextstringsEditorCulture & IRichtextEditor & IRichtextEditorCulture & ISliderEditor & ISliderEditorCulture & ITagsEditor & ITagsEditorCulture & ITextareaEditor & ITextareaEditorCulture & ITextboxEditor & ITextboxEditorCulture & IToggleEditor & IToggleEditorCulture & IUserPickerEditor & IUserPickerEditorCulture & IDefaultCulture {
-  blockList: BlockList
-  blockListCulture: BlockList
-  checkboxList: DefaultProperty
-  checkboxListCulture: DefaultProperty
-  colorPicker: DefaultProperty
-  colorPickerCulture: DefaultProperty
-  contentPicker: ContentPicker
-  contentPickerCulture: ContentPicker
-  datePicker: DateTimePicker
-  datePickerWithTime: DateTimePicker
-  datePickerCulture: DateTimePicker
-  datePickerWithTimeCulture: DateTimePicker
-  decimal: DefaultProperty
-  decimalCulture: DefaultProperty
-  dropdown: DefaultProperty
-  dropdownCulture: DefaultProperty
-  emailAddress: DefaultProperty
-  emailAddressCulture: DefaultProperty
-  eyeDropperColorPicker: DefaultProperty
-  eyeDropperColorPickerCulture: DefaultProperty
-  article: DefaultProperty
-  audio: DefaultProperty
-  file: DefaultProperty
-  svg: DefaultProperty
-  video: DefaultProperty
-  articleCulture: DefaultProperty
-  audioCulture: DefaultProperty
-  fileCulture: DefaultProperty
-  svgCulture: DefaultProperty
-  videoCulture: DefaultProperty
-  imageCropper: DefaultProperty
-  imageCropperCulture: DefaultProperty
-  markdown: RichText
-  markdownCulture: RichText
-  imageMediaPicker: MediaPicker
-  mediaPicker: MediaPicker
-  multipleImageMediaPicker: MediaPicker
-  multipleMediaPicker: MediaPicker
-  imageMediaPickerCulture: MediaPicker
-  mediaPickerCulture: MediaPicker
-  multipleImageMediaPickerCulture: MediaPicker
-  multipleMediaPickerCulture: MediaPicker
-  memberGroupPicker: DefaultProperty
-  memberGroupPickerCulture: DefaultProperty
-  memberPicker: MemberPicker
-  memberPickerCulture: MemberPicker
-  multinodeTreepicker: ContentPicker
-  multinodeTreepickerCulture: ContentPicker
-  multiUrlPicker: MultiUrlPicker
-  multiUrlPickerCulture: MultiUrlPicker
-  numeric: DefaultProperty
-  numericCulture: DefaultProperty
-  radiobox: DefaultProperty
-  radioboxCulture: DefaultProperty
-  repeatableTextstrings: DefaultProperty
-  repeatableTextstringsCulture: DefaultProperty
-  richtext: RichText
-  richtextCulture: RichText
-  slider: DefaultProperty
-  sliderCulture: DefaultProperty
-  tags: DefaultProperty
-  tagsCulture: DefaultProperty
-  textarea: DefaultProperty
-  textareaCulture: DefaultProperty
-  textstring: DefaultProperty
-  textstringCulture: DefaultProperty
-  trueOrFalse: DefaultProperty
-  trueOrFalseCulture: DefaultProperty
-  userPicker: DefaultProperty
-  userPickerCulture: DefaultProperty
-}
-
-"A catch all property value that simply returns the value of the property. This is all that is needed for simple properties that doesn't need any special handling or formatting."
-type DefaultProperty implements PropertyValue {
-  "Gets the value of the property."
-  value: Any
-  "The model of the property value"
-  model: String!
-}
-
-type DropdownEditor implements IDropdownEditor {
-  dropdown: DefaultProperty
-}
-
-type DropdownEditorCulture implements IDropdownEditorCulture {
-  dropdownCulture: DefaultProperty
-}
-
-type EmailAddressEditor implements IEmailAddressEditor {
-  emailAddress: DefaultProperty
-}
-
-type EmailAddressEditorCulture implements IEmailAddressEditorCulture {
-  emailAddressCulture: DefaultProperty
-}
-
-"Represents a content type that doesn't have any properties and therefore needs a placeholder"
-type EmptyPropertyType {
-  "Placeholder field. Will never hold a value."
-  Empty_Field: String!
-}
-
-type EyeDropperColorPickerEditor implements IEyeDropperColorPickerEditor {
-  eyeDropperColorPicker: DefaultProperty
-}
-
-type EyeDropperColorPickerEditorCulture implements IEyeDropperColorPickerEditorCulture {
-  eyeDropperColorPickerCulture: DefaultProperty
-}
-
-type File implements IFile {
-  umbracoFile: DefaultProperty
-  umbracoExtension: Label
-  "in bytes"
-  umbracoBytes: Label
-}
-
-type FileUpload implements IFileUpload {
-  article: DefaultProperty
-  audio: DefaultProperty
-  file: DefaultProperty
-  svg: DefaultProperty
-  video: DefaultProperty
-}
-
-type FileUploadCulture implements IFileUploadCulture {
-  articleCulture: DefaultProperty
-  audioCulture: DefaultProperty
-  fileCulture: DefaultProperty
-  svgCulture: DefaultProperty
-  videoCulture: DefaultProperty
-}
-
-"Represents focal point coordinates for an image."
-type FocalPoint {
-  "The left coordinate (0.0 to 1.0)"
-  left: Decimal!
-  "The top coordinate (0.0 to 1.0)"
-  top: Decimal!
-}
-
-type Image implements IImage {
-  umbracoFile: DefaultProperty
-  "in pixels"
-  umbracoWidth: Label
-  "in pixels"
-  umbracoHeight: Label
-  "in bytes"
-  umbracoBytes: Label
-  umbracoExtension: Label
-}
-
-type ImageCropperEditor implements IImageCropperEditor {
-  imageCropper: DefaultProperty
-}
-
-type ImageCropperEditorCulture implements IImageCropperEditorCulture {
-  imageCropperCulture: DefaultProperty
-}
-
-"A JWT token."
-type JwtToken {
-  "The JWT token."
-  token: String!
-  "The expiration time of the token in Unix timestamp."
-  expires: Long!
-  "The prefix used when using the token."
-  prefix: String!
-  "The header used when using the token."
-  header: String!
-}
-
-type Label implements PropertyValue {
-  "Gets the value of the property."
-  value: Any
-  "The model of the property value"
-  model: String!
-}
-
-type LabelEditor implements ILabelEditor {
-  bigint: Label
-  datetime: Label
-  decimal: Label
-  integer: Label
-  string: Label
-  time: Label
-}
-
-type LabelEditorCulture implements ILabelEditorCulture {
-  bigintCulture: Label
-  datetimeCulture: Label
-  decimalCulture: Label
-  integerCulture: Label
-  stringCulture: Label
-  timeCulture: Label
-}
-
-type MarkdownEditor implements IMarkdownEditor {
-  markdown: RichText
-}
-
-type MarkdownEditorCulture implements IMarkdownEditorCulture {
-  markdownCulture: RichText
-}
-
-type MediaItem {
-  "Gets the url of a media item."
-  url(urlMode: UrlMode! propertyAlias: String! = "umbracoFile"): String
-  "Gets the parent of the media item."
-  parent: MediaItem
-  "Gets the properties of the media item."
-  properties: TypedProperties!
-  "Gets the url segment of the media item."
-  urlSegment: String
-  "Gets the name of a media item."
-  name: String
-  "Gets the id of a media item."
-  id: Int
-  "Gets the key of a media item."
-  key: UUID
-  "Gets the identifier of the template to use to render the media item."
-  templateId: Int
-  "Gets the date the media item was last updated."
-  updateDate: DateTime
-}
-
-"Represents a media picker item."
-type MediaPicker implements PropertyValue {
-  "Gets the media items of a picker."
-  mediaItems: [MediaPickerItem!]!
-  "The model of the property value"
-  model: String!
-}
-
-type MediaPickerEditor implements IMediaPickerEditor {
-  imageMediaPicker: MediaPicker
-  mediaPicker: MediaPicker
-  multipleImageMediaPicker: MediaPicker
-  multipleMediaPicker: MediaPicker
-}
-
-type MediaPickerEditorCulture implements IMediaPickerEditorCulture {
-  imageMediaPickerCulture: MediaPicker
-  mediaPickerCulture: MediaPicker
-  multipleImageMediaPickerCulture: MediaPicker
-  multipleMediaPickerCulture: MediaPicker
-}
-
-"Represents a media item."
-type MediaPickerItem {
-  "Gets the url of a media item."
-  url(urlMode: UrlMode!): String!
-  "Gets the focal point of an image."
-  focalPoint: FocalPoint
-  "Gets the properties of the media item."
-  properties: TypedProperties!
-  "Gets the url segment of the media item."
-  urlSegment: String
-  "Gets the name of a media item."
-  name: String
-  "Gets the id of a media item."
-  id: Int!
-  "Gets the key of a media item."
-  key: UUID!
-}
-
-type Member implements IMember {
-  umbracoMemberComments: DefaultProperty
-  umbracoMemberFailedPasswordAttempts: Label
-  umbracoMemberApproved: DefaultProperty
-  umbracoMemberLockedOut: DefaultProperty
-  umbracoMemberLastLockoutDate: Label
-  umbracoMemberLastLogin: Label
-  umbracoMemberLastPasswordChangeDate: Label
-}
-
-type MemberGroupPickerEditor implements IMemberGroupPickerEditor {
-  memberGroupPicker: DefaultProperty
-}
-
-type MemberGroupPickerEditorCulture implements IMemberGroupPickerEditorCulture {
-  memberGroupPickerCulture: DefaultProperty
-}
-
-type MemberItem {
-  "Gets the properties of the member item."
-  properties: TypedProperties!
-  "Gets the name of a member item."
-  name: String
-  "Gets the id of a member item."
-  id: Int
-  "Gets the key of a member item."
-  key: UUID
-  "Gets the identifier of the template to use to render the member item."
-  templateId: Int
-  "Gets the date the member item was last updated."
-  updateDate: DateTime
-}
-
-"Represents a member picker."
-type MemberPicker implements PropertyValue {
-  "Gets the member items of a picker. Requires the property.values.member.picker or global.member.read claim to access"
-  members: [MemberPickerItem!]! @authorize(policy: "PropertyValuesMemberPicker")
-  "The model of the property value"
-  model: String!
-}
-
-type MemberPickerEditor implements IMemberPickerEditor {
-  memberPicker: MemberPicker
-}
-
-type MemberPickerEditorCulture implements IMemberPickerEditorCulture {
-  memberPickerCulture: MemberPicker
-}
-
-"Represents a member item."
-type MemberPickerItem {
-  "Gets the properties of the member item."
-  properties: TypedProperties!
-  "Gets the name of a member item."
-  name: String
-  "Gets the id of a member item."
-  id: Int!
-  "Gets the key of a member item."
-  key: UUID!
-}
-
-"Represents a multi url picker."
-type MultiUrlPicker implements PropertyValue {
-  "Gets the links of the picker."
-  links: [MultiUrlPickerItem!]!
-  "The model of the property value"
-  model: String!
-}
-
-type MultiUrlPickerEditor implements IMultiUrlPickerEditor {
-  multiUrlPicker: MultiUrlPicker
-}
-
-type MultiUrlPickerEditorCulture implements IMultiUrlPickerEditorCulture {
-  multiUrlPickerCulture: MultiUrlPicker
-}
-
-"Represents a content item."
-type MultiUrlPickerItem {
-  "Gets the url of a content item. If the link isn't to a content item or media item then the UrlMode doesn't affect the url."
-  url(urlMode: UrlMode!): String!
-  "Gets the properties of the content item."
-  properties: TypedProperties!
-  "Gets the url segment of the content item."
-  urlSegment: String
-  "Gets the target of the link."
-  target: String
-  "Gets the type of the link."
-  type: LinkType!
-  "Gets the title of the link."
-  title: String
-  "Gets the name of a content item."
-  name: String
-  "Gets the id of a content item."
-  id: Int
-  "Gets the key of a content item."
-  key: UUID
-}
-
-type MultinodeTreepickerEditor implements IMultinodeTreepickerEditor {
-  multinodeTreepicker: ContentPicker
-}
-
-type MultinodeTreepickerEditorCulture implements IMultinodeTreepickerEditorCulture {
-  multinodeTreepickerCulture: ContentPicker
-}
-
-"The base mutation object"
-type Mutation {
-  "Creates a JWT token to be used for other queries."
-  createToken("The claims of the token." claims: [TokenClaimInput!]!): JwtToken! @authorize(policy: "CreateTokenMutation")
-}
-
-"Represents nested content."
-type NestedContent implements PropertyValue {
-  "Gets the elements of a nested content."
-  elements: [NestedContentItem!]!
-  "The model of the property value"
-  model: String!
-}
-
-type NestedContentItem {
-  "Gets the properties of the nested content."
-  properties: TypedNestedContentProperties!
-}
-
-type NumericEditor implements INumericEditor {
-  numeric: DefaultProperty
-}
-
-type NumericEditorCulture implements INumericEditorCulture {
-  numericCulture: DefaultProperty
-}
-
-"Represents a paginated list of items."
-type PaginationOfContentItem {
-  "The page number."
-  page: Int!
-  "The page size"
-  pageSize: Int!
-  "The total number of items."
-  totalItems: Int!
-  "Whether there is a next page."
-  hasNextPage: Boolean!
-  "The items in the paginated list."
-  items: [ContentItem!]!
-}
-
-"Represents a paginated list of items."
-type PaginationOfMediaItem {
-  "The page number."
-  page: Int!
-  "The page size"
-  pageSize: Int!
-  "The total number of items."
-  totalItems: Int!
-  "Whether there is a next page."
-  hasNextPage: Boolean!
-  "The items in the paginated list."
-  items: [MediaItem!]!
-}
-
-"Represents a paginated list of items."
-type PaginationOfMemberItem {
-  "The page number."
-  page: Int!
-  "The page size"
-  pageSize: Int!
-  "The total number of items."
-  totalItems: Int!
-  "Whether there is a next page."
-  hasNextPage: Boolean!
-  "The items in the paginated list."
-  items: [MemberItem!]!
-}
-
-"The base query object"
-type Query {
-  "Utility query. Gets a which claims are used by the registered queries."
-  utility_GetClaimGroups: [ClaimGroup!]!
-  "Gets a content item by a route."
-  contentByRoute("The route to fetch. Example '\/da\/frontpage\/'." route: String! "The context of the request." inContext: QueryContextInput): ContentItem @authorize(policy: "ContentByRouteQuery")
-  "Gets all the content items by content type."
-  contentByContentType("The contentType to fetch." contentType: String! "How many items to include in a page. Defaults to 10." pageSize: Int! = 10 "The page number to fetch. Defaults to 1." page: Int! = 1 "The context of the request." inContext: QueryContextInput): PaginationOfContentItem! @authorize(policy: "ContentByContentTypeQuery")
-  "Gets all the content items at root level."
-  contentAtRoot("How many items to include in a page. Defaults to 10." pageSize: Int! = 10 "The page number to fetch. Defaults to 1." page: Int! = 1 "The context of the request." inContext: QueryContextInput): PaginationOfContentItem! @authorize(policy: "ContentAtRootQuery")
-  "Gets a content item by id."
-  contentById("The id to fetch." id: Int! "The context of the request." inContext: QueryContextInput): ContentItem @authorize(policy: "ContentByIdQuery")
-  "Gets a content item by Guid."
-  contentByGuid("The id to fetch." id: UUID! "The context of the request." inContext: QueryContextInput): ContentItem @authorize(policy: "ContentByGuidQuery")
-  "Gets content items by tag."
-  contentByTag("The tag to fetch." tag: String! "The tag group to fetch." tagGroup: String "How many items to include in a page. Defaults to 10." pageSize: Int! = 10 "The page number to fetch. Defaults to 1." page: Int! = 1 "The context of the request." inContext: QueryContextInput): PaginationOfContentItem! @authorize(policy: "ContentByTagQuery")
-  "Gets all the media items by content type."
-  mediaByContentType("The content type to fetch." contentType: String! "How many items to include in a page. Defaults to 10." pageSize: Int! = 10 "The page number to fetch. Defaults to 1." page: Int! = 1): PaginationOfMediaItem! @authorize(policy: "MediaByContentTypeQuery")
-  "Gets all the media items at root level."
-  mediaAtRoot("How many items to include in a page. Defaults to 10." pageSize: Int! = 10 "The page number to fetch. Defaults to 1." page: Int! = 1): PaginationOfMediaItem! @authorize(policy: "MediaAtRootQuery")
-  "Gets a Media item by id."
-  mediaById("The id to fetch." id: Int!): MediaItem @authorize(policy: "MediaByIdQuery")
-  "Gets a Media item by Guid."
-  mediaByGuid("The Guid to fetch." id: UUID!): MediaItem @authorize(policy: "MediaByGuidQuery")
-  "Finds members by display name."
-  findMembersByDisplayName("The display name (may be partial)." displayName: String! "Determines how to match a string property value." matchType: StringPropertyMatchType! "The page number to fetch. Defaults to 1." page: Int! = 1 "How many items to include in a page. Defaults to 10." pageSize: Int! = 10): [MemberItem]! @authorize(policy: "FindMembersByDisplayNameQuery")
-  "Finds members by email."
-  findMembersByEmail("The email (may be partial)." email: String! "Determines how to match a string property value." matchType: StringPropertyMatchType! "The page number to fetch. Defaults to 1." page: Int! = 1 "How many items to include in a page. Defaults to 10." pageSize: Int! = 10): [MemberItem]! @authorize(policy: "FindMembersByEmailQuery")
-  "Finds members by role."
-  findMembersByRole("The role name." roleName: String! "The username to match." usernameToMatch: String! "Determines how to match a string property value." matchType: StringPropertyMatchType! "How many items to include in a page. Defaults to 10." pageSize: Int! = 10 "The page number to fetch. Defaults to 1." page: Int! = 1): PaginationOfMemberItem! @authorize(policy: "FindMembersByRoleQuery")
-  "Finds members by username."
-  findMembersByUsername("The username (may be partial)." username: String! "Determines how to match a string property value." matchType: StringPropertyMatchType! "The page number to fetch. Defaults to 1." page: Int! = 1 "How many items to include in a page. Defaults to 10." pageSize: Int! = 10): [MemberItem]! @authorize(policy: "FindMembersByUsernameQuery")
-  "Gets a member by email."
-  memberByEmail("The email to fetch." email: String!): MemberItem @authorize(policy: "MemberByEmailQuery")
-  "Gets a member by Guid."
-  memberByGuid("The id to fetch." id: UUID!): MemberItem @authorize(policy: "MemberByGuidQuery")
-  "Gets a member by id."
-  memberById("The id to fetch." id: Int!): MemberItem @authorize(policy: "MemberByIdQuery")
-  "Gets a member by username."
-  memberByUsername("The username to fetch." username: String!): MemberItem @authorize(policy: "MemberByUsernameQuery")
-}
-
-type RadioboxEditor implements IRadioboxEditor {
-  radiobox: DefaultProperty
-}
-
-type RadioboxEditorCulture implements IRadioboxEditorCulture {
-  radioboxCulture: DefaultProperty
-}
-
-type RedirectInfo {
-  redirectUrl: String
-  isPermanent: Boolean!
-}
-
-type RepeatableTextstringsEditor implements IRepeatableTextstringsEditor {
-  repeatableTextstrings: DefaultProperty
-}
-
-type RepeatableTextstringsEditorCulture implements IRepeatableTextstringsEditorCulture {
-  repeatableTextstringsCulture: DefaultProperty
-}
-
-"Represents a rich text editor."
-type RichText implements PropertyValue {
-  "Gets the HTML value of the rich text editor or markdown editor."
-  value: String
-  "Gets the original value of the rich text editor or markdown editor."
-  sourceValue: String
-  "The model of the property value"
-  model: String!
-}
-
-type RichtextEditor implements IRichtextEditor {
-  richtext: RichText
-}
-
-type RichtextEditorCulture implements IRichtextEditorCulture {
-  richtextCulture: RichText
-}
-
-type SiteWithCulture implements ITextboxEditor & ITextboxEditorCulture & ISiteWithCulture {
-  textstring: DefaultProperty
-  textstringCulture: DefaultProperty
-}
-
-type SliderEditor implements ISliderEditor {
-  slider: DefaultProperty
-}
-
-type SliderEditorCulture implements ISliderEditorCulture {
-  sliderCulture: DefaultProperty
-}
-
-type TagsEditor implements ITagsEditor {
-  tags: DefaultProperty
-}
-
-type TagsEditorCulture implements ITagsEditorCulture {
-  tagsCulture: DefaultProperty
-}
-
-type TestMember implements ITestMember {
-  blockList: BlockList
-  nestedContent: MemberPicker
-  umbracoMemberComments: DefaultProperty
-}
-
-type TextareaEditor implements ITextareaEditor {
-  textarea: DefaultProperty
-}
-
-type TextareaEditorCulture implements ITextareaEditorCulture {
-  textareaCulture: DefaultProperty
-}
-
-type TextboxEditor implements ITextboxEditor {
-  textstring: DefaultProperty
-}
-
-type TextboxEditorCulture implements ITextboxEditorCulture {
-  textstringCulture: DefaultProperty
-}
-
-type ToggleEditor implements IToggleEditor {
-  trueOrFalse: DefaultProperty
-}
-
-type ToggleEditorCulture implements IToggleEditorCulture {
-  trueOrFalseCulture: DefaultProperty
-}
-
-type UmbBlockGridDemoHeadlineBlock implements IUmbBlockGridDemoHeadlineBlock {
-  headline: DefaultProperty
-}
-
-type UmbBlockGridDemoImageBlock implements IUmbBlockGridDemoImageBlock {
-  image: MediaPicker
-}
-
-type UmbBlockGridDemoRichTextBlock implements IUmbBlockGridDemoRichTextBlock {
-  richText: RichText
-}
-
-type UmbracoMediaArticle implements IUmbracoMediaArticle {
-  umbracoFile: DefaultProperty
-  umbracoExtension: Label
-  "in bytes"
-  umbracoBytes: Label
-}
-
-type UmbracoMediaAudio implements IUmbracoMediaAudio {
-  umbracoFile: DefaultProperty
-  umbracoExtension: Label
-  "in bytes"
-  umbracoBytes: Label
-}
-
-type UmbracoMediaVectorGraphics implements IUmbracoMediaVectorGraphics {
-  umbracoFile: DefaultProperty
-  umbracoExtension: Label
-  "in bytes"
-  umbracoBytes: Label
-}
-
-type UmbracoMediaVideo implements IUmbracoMediaVideo {
-  umbracoFile: DefaultProperty
-  umbracoExtension: Label
-  "in bytes"
-  umbracoBytes: Label
-}
-
-"Represents an unsupported property value."
-type UnsupportedProperty implements PropertyValue {
-  "Gets the message of the property."
-  message: String!
-  "The model of the property value"
-  model: String!
-}
-
-type UserPickerEditor implements IUserPickerEditor {
-  userPicker: DefaultProperty
-}
-
-type UserPickerEditorCulture implements IUserPickerEditorCulture {
-  userPickerCulture: DefaultProperty
-}
-
 "Used to get typed properties on a block grid property for the content property"
-union TypedBlockGridContentProperties = EmptyPropertyType | BlockGridEditor | BlockListEditor | BlockListEditorCulture | CheckboxListEditor | CheckboxListEditorCulture | ColorPickerEditor | ColorPickerEditorCulture | ContentPickerEditor | ContentPickerEditorCulture | DatePickerEditor | DatePickerEditorCulture | DecimalEditor | DecimalEditorCulture | Default | DefaultCulture | DropdownEditor | DropdownEditorCulture | EmailAddressEditor | EmailAddressEditorCulture | EyeDropperColorPickerEditor | EyeDropperColorPickerEditorCulture | FileUpload | FileUploadCulture | ImageCropperEditor | ImageCropperEditorCulture | LabelEditor | LabelEditorCulture | MarkdownEditor | MarkdownEditorCulture | MediaPickerEditor | MediaPickerEditorCulture | MemberGroupPickerEditor | MemberGroupPickerEditorCulture | MemberPickerEditor | MemberPickerEditorCulture | MultinodeTreepickerEditor | MultinodeTreepickerEditorCulture | MultiUrlPickerEditor | MultiUrlPickerEditorCulture | NumericEditor | NumericEditorCulture | RadioboxEditor | RadioboxEditorCulture | RepeatableTextstringsEditor | RepeatableTextstringsEditorCulture | RichtextEditor | RichtextEditorCulture | SiteWithCulture | SliderEditor | SliderEditorCulture | TagsEditor | TagsEditorCulture | TextareaEditor | TextareaEditorCulture | TextboxEditor | TextboxEditorCulture | ToggleEditor | ToggleEditorCulture | UmbBlockGridDemoHeadlineBlock | UmbBlockGridDemoImageBlock | UmbBlockGridDemoRichTextBlock | UserPickerEditor | UserPickerEditorCulture | BlockGridEditor1 | Image | File | UmbracoMediaVideo | UmbracoMediaAudio | UmbracoMediaArticle | UmbracoMediaVectorGraphics | CustomMediaType | Member | TestMember
+union TypedBlockGridContentProperties =
+  | EmptyPropertyType
+  | BlockGridEditor
+  | BlockListEditor
+  | BlockListEditorCulture
+  | CheckboxListEditor
+  | CheckboxListEditorCulture
+  | ColorPickerEditor
+  | ColorPickerEditorCulture
+  | ContentPickerEditor
+  | ContentPickerEditorCulture
+  | DatePickerEditor
+  | DatePickerEditorCulture
+  | DecimalEditor
+  | DecimalEditorCulture
+  | Default
+  | DefaultCulture
+  | DropdownEditor
+  | DropdownEditorCulture
+  | EmailAddressEditor
+  | EmailAddressEditorCulture
+  | EyeDropperColorPickerEditor
+  | EyeDropperColorPickerEditorCulture
+  | FileUpload
+  | FileUploadCulture
+  | ImageCropperEditor
+  | ImageCropperEditorCulture
+  | LabelEditor
+  | LabelEditorCulture
+  | MarkdownEditor
+  | MarkdownEditorCulture
+  | MediaPickerEditor
+  | MediaPickerEditorCulture
+  | MemberGroupPickerEditor
+  | MemberGroupPickerEditorCulture
+  | MemberPickerEditor
+  | MemberPickerEditorCulture
+  | MultinodeTreepickerEditor
+  | MultinodeTreepickerEditorCulture
+  | MultiUrlPickerEditor
+  | MultiUrlPickerEditorCulture
+  | NumericEditor
+  | NumericEditorCulture
+  | RadioboxEditor
+  | RadioboxEditorCulture
+  | RepeatableTextstringsEditor
+  | RepeatableTextstringsEditorCulture
+  | RichtextEditor
+  | RichtextEditorCulture
+  | SiteWithCulture
+  | SliderEditor
+  | SliderEditorCulture
+  | TagsEditor
+  | TagsEditorCulture
+  | TextareaEditor
+  | TextareaEditorCulture
+  | TextboxEditor
+  | TextboxEditorCulture
+  | ToggleEditor
+  | ToggleEditorCulture
+  | UmbBlockGridDemoHeadlineBlock
+  | UmbBlockGridDemoImageBlock
+  | UmbBlockGridDemoRichTextBlock
+  | UserPickerEditor
+  | UserPickerEditorCulture
+  | BlockGridEditor1
+  | Image
+  | File
+  | UmbracoMediaVideo
+  | UmbracoMediaAudio
+  | UmbracoMediaArticle
+  | UmbracoMediaVectorGraphics
+  | CustomMediaType
+  | Member
+  | TestMember
 
 "Used to get typed properties on a block grid property for the settings property"
-union TypedBlockGridSettingsProperties = EmptyPropertyType | BlockGridEditor | BlockListEditor | BlockListEditorCulture | CheckboxListEditor | CheckboxListEditorCulture | ColorPickerEditor | ColorPickerEditorCulture | ContentPickerEditor | ContentPickerEditorCulture | DatePickerEditor | DatePickerEditorCulture | DecimalEditor | DecimalEditorCulture | Default | DefaultCulture | DropdownEditor | DropdownEditorCulture | EmailAddressEditor | EmailAddressEditorCulture | EyeDropperColorPickerEditor | EyeDropperColorPickerEditorCulture | FileUpload | FileUploadCulture | ImageCropperEditor | ImageCropperEditorCulture | LabelEditor | LabelEditorCulture | MarkdownEditor | MarkdownEditorCulture | MediaPickerEditor | MediaPickerEditorCulture | MemberGroupPickerEditor | MemberGroupPickerEditorCulture | MemberPickerEditor | MemberPickerEditorCulture | MultinodeTreepickerEditor | MultinodeTreepickerEditorCulture | MultiUrlPickerEditor | MultiUrlPickerEditorCulture | NumericEditor | NumericEditorCulture | RadioboxEditor | RadioboxEditorCulture | RepeatableTextstringsEditor | RepeatableTextstringsEditorCulture | RichtextEditor | RichtextEditorCulture | SiteWithCulture | SliderEditor | SliderEditorCulture | TagsEditor | TagsEditorCulture | TextareaEditor | TextareaEditorCulture | TextboxEditor | TextboxEditorCulture | ToggleEditor | ToggleEditorCulture | UmbBlockGridDemoHeadlineBlock | UmbBlockGridDemoImageBlock | UmbBlockGridDemoRichTextBlock | UserPickerEditor | UserPickerEditorCulture | BlockGridEditor1 | Image | File | UmbracoMediaVideo | UmbracoMediaAudio | UmbracoMediaArticle | UmbracoMediaVectorGraphics | CustomMediaType | Member | TestMember
+union TypedBlockGridSettingsProperties =
+  | EmptyPropertyType
+  | BlockGridEditor
+  | BlockListEditor
+  | BlockListEditorCulture
+  | CheckboxListEditor
+  | CheckboxListEditorCulture
+  | ColorPickerEditor
+  | ColorPickerEditorCulture
+  | ContentPickerEditor
+  | ContentPickerEditorCulture
+  | DatePickerEditor
+  | DatePickerEditorCulture
+  | DecimalEditor
+  | DecimalEditorCulture
+  | Default
+  | DefaultCulture
+  | DropdownEditor
+  | DropdownEditorCulture
+  | EmailAddressEditor
+  | EmailAddressEditorCulture
+  | EyeDropperColorPickerEditor
+  | EyeDropperColorPickerEditorCulture
+  | FileUpload
+  | FileUploadCulture
+  | ImageCropperEditor
+  | ImageCropperEditorCulture
+  | LabelEditor
+  | LabelEditorCulture
+  | MarkdownEditor
+  | MarkdownEditorCulture
+  | MediaPickerEditor
+  | MediaPickerEditorCulture
+  | MemberGroupPickerEditor
+  | MemberGroupPickerEditorCulture
+  | MemberPickerEditor
+  | MemberPickerEditorCulture
+  | MultinodeTreepickerEditor
+  | MultinodeTreepickerEditorCulture
+  | MultiUrlPickerEditor
+  | MultiUrlPickerEditorCulture
+  | NumericEditor
+  | NumericEditorCulture
+  | RadioboxEditor
+  | RadioboxEditorCulture
+  | RepeatableTextstringsEditor
+  | RepeatableTextstringsEditorCulture
+  | RichtextEditor
+  | RichtextEditorCulture
+  | SiteWithCulture
+  | SliderEditor
+  | SliderEditorCulture
+  | TagsEditor
+  | TagsEditorCulture
+  | TextareaEditor
+  | TextareaEditorCulture
+  | TextboxEditor
+  | TextboxEditorCulture
+  | ToggleEditor
+  | ToggleEditorCulture
+  | UmbBlockGridDemoHeadlineBlock
+  | UmbBlockGridDemoImageBlock
+  | UmbBlockGridDemoRichTextBlock
+  | UserPickerEditor
+  | UserPickerEditorCulture
+  | BlockGridEditor1
+  | Image
+  | File
+  | UmbracoMediaVideo
+  | UmbracoMediaAudio
+  | UmbracoMediaArticle
+  | UmbracoMediaVectorGraphics
+  | CustomMediaType
+  | Member
+  | TestMember
 
 "Used to get typed properties on a block list property for the content property"
-union TypedBlockListContentProperties = EmptyPropertyType | BlockGridEditor | BlockListEditor | BlockListEditorCulture | CheckboxListEditor | CheckboxListEditorCulture | ColorPickerEditor | ColorPickerEditorCulture | ContentPickerEditor | ContentPickerEditorCulture | DatePickerEditor | DatePickerEditorCulture | DecimalEditor | DecimalEditorCulture | Default | DefaultCulture | DropdownEditor | DropdownEditorCulture | EmailAddressEditor | EmailAddressEditorCulture | EyeDropperColorPickerEditor | EyeDropperColorPickerEditorCulture | FileUpload | FileUploadCulture | ImageCropperEditor | ImageCropperEditorCulture | LabelEditor | LabelEditorCulture | MarkdownEditor | MarkdownEditorCulture | MediaPickerEditor | MediaPickerEditorCulture | MemberGroupPickerEditor | MemberGroupPickerEditorCulture | MemberPickerEditor | MemberPickerEditorCulture | MultinodeTreepickerEditor | MultinodeTreepickerEditorCulture | MultiUrlPickerEditor | MultiUrlPickerEditorCulture | NumericEditor | NumericEditorCulture | RadioboxEditor | RadioboxEditorCulture | RepeatableTextstringsEditor | RepeatableTextstringsEditorCulture | RichtextEditor | RichtextEditorCulture | SiteWithCulture | SliderEditor | SliderEditorCulture | TagsEditor | TagsEditorCulture | TextareaEditor | TextareaEditorCulture | TextboxEditor | TextboxEditorCulture | ToggleEditor | ToggleEditorCulture | UmbBlockGridDemoHeadlineBlock | UmbBlockGridDemoImageBlock | UmbBlockGridDemoRichTextBlock | UserPickerEditor | UserPickerEditorCulture | BlockGridEditor1 | Image | File | UmbracoMediaVideo | UmbracoMediaAudio | UmbracoMediaArticle | UmbracoMediaVectorGraphics | CustomMediaType | Member | TestMember
+union TypedBlockListContentProperties =
+  | EmptyPropertyType
+  | BlockGridEditor
+  | BlockListEditor
+  | BlockListEditorCulture
+  | CheckboxListEditor
+  | CheckboxListEditorCulture
+  | ColorPickerEditor
+  | ColorPickerEditorCulture
+  | ContentPickerEditor
+  | ContentPickerEditorCulture
+  | DatePickerEditor
+  | DatePickerEditorCulture
+  | DecimalEditor
+  | DecimalEditorCulture
+  | Default
+  | DefaultCulture
+  | DropdownEditor
+  | DropdownEditorCulture
+  | EmailAddressEditor
+  | EmailAddressEditorCulture
+  | EyeDropperColorPickerEditor
+  | EyeDropperColorPickerEditorCulture
+  | FileUpload
+  | FileUploadCulture
+  | ImageCropperEditor
+  | ImageCropperEditorCulture
+  | LabelEditor
+  | LabelEditorCulture
+  | MarkdownEditor
+  | MarkdownEditorCulture
+  | MediaPickerEditor
+  | MediaPickerEditorCulture
+  | MemberGroupPickerEditor
+  | MemberGroupPickerEditorCulture
+  | MemberPickerEditor
+  | MemberPickerEditorCulture
+  | MultinodeTreepickerEditor
+  | MultinodeTreepickerEditorCulture
+  | MultiUrlPickerEditor
+  | MultiUrlPickerEditorCulture
+  | NumericEditor
+  | NumericEditorCulture
+  | RadioboxEditor
+  | RadioboxEditorCulture
+  | RepeatableTextstringsEditor
+  | RepeatableTextstringsEditorCulture
+  | RichtextEditor
+  | RichtextEditorCulture
+  | SiteWithCulture
+  | SliderEditor
+  | SliderEditorCulture
+  | TagsEditor
+  | TagsEditorCulture
+  | TextareaEditor
+  | TextareaEditorCulture
+  | TextboxEditor
+  | TextboxEditorCulture
+  | ToggleEditor
+  | ToggleEditorCulture
+  | UmbBlockGridDemoHeadlineBlock
+  | UmbBlockGridDemoImageBlock
+  | UmbBlockGridDemoRichTextBlock
+  | UserPickerEditor
+  | UserPickerEditorCulture
+  | BlockGridEditor1
+  | Image
+  | File
+  | UmbracoMediaVideo
+  | UmbracoMediaAudio
+  | UmbracoMediaArticle
+  | UmbracoMediaVectorGraphics
+  | CustomMediaType
+  | Member
+  | TestMember
 
 "Used to get typed properties on a block list property for the settings property"
-union TypedBlockListSettingsProperties = EmptyPropertyType | BlockGridEditor | BlockListEditor | BlockListEditorCulture | CheckboxListEditor | CheckboxListEditorCulture | ColorPickerEditor | ColorPickerEditorCulture | ContentPickerEditor | ContentPickerEditorCulture | DatePickerEditor | DatePickerEditorCulture | DecimalEditor | DecimalEditorCulture | Default | DefaultCulture | DropdownEditor | DropdownEditorCulture | EmailAddressEditor | EmailAddressEditorCulture | EyeDropperColorPickerEditor | EyeDropperColorPickerEditorCulture | FileUpload | FileUploadCulture | ImageCropperEditor | ImageCropperEditorCulture | LabelEditor | LabelEditorCulture | MarkdownEditor | MarkdownEditorCulture | MediaPickerEditor | MediaPickerEditorCulture | MemberGroupPickerEditor | MemberGroupPickerEditorCulture | MemberPickerEditor | MemberPickerEditorCulture | MultinodeTreepickerEditor | MultinodeTreepickerEditorCulture | MultiUrlPickerEditor | MultiUrlPickerEditorCulture | NumericEditor | NumericEditorCulture | RadioboxEditor | RadioboxEditorCulture | RepeatableTextstringsEditor | RepeatableTextstringsEditorCulture | RichtextEditor | RichtextEditorCulture | SiteWithCulture | SliderEditor | SliderEditorCulture | TagsEditor | TagsEditorCulture | TextareaEditor | TextareaEditorCulture | TextboxEditor | TextboxEditorCulture | ToggleEditor | ToggleEditorCulture | UmbBlockGridDemoHeadlineBlock | UmbBlockGridDemoImageBlock | UmbBlockGridDemoRichTextBlock | UserPickerEditor | UserPickerEditorCulture | BlockGridEditor1 | Image | File | UmbracoMediaVideo | UmbracoMediaAudio | UmbracoMediaArticle | UmbracoMediaVectorGraphics | CustomMediaType | Member | TestMember
+union TypedBlockListSettingsProperties =
+  | EmptyPropertyType
+  | BlockGridEditor
+  | BlockListEditor
+  | BlockListEditorCulture
+  | CheckboxListEditor
+  | CheckboxListEditorCulture
+  | ColorPickerEditor
+  | ColorPickerEditorCulture
+  | ContentPickerEditor
+  | ContentPickerEditorCulture
+  | DatePickerEditor
+  | DatePickerEditorCulture
+  | DecimalEditor
+  | DecimalEditorCulture
+  | Default
+  | DefaultCulture
+  | DropdownEditor
+  | DropdownEditorCulture
+  | EmailAddressEditor
+  | EmailAddressEditorCulture
+  | EyeDropperColorPickerEditor
+  | EyeDropperColorPickerEditorCulture
+  | FileUpload
+  | FileUploadCulture
+  | ImageCropperEditor
+  | ImageCropperEditorCulture
+  | LabelEditor
+  | LabelEditorCulture
+  | MarkdownEditor
+  | MarkdownEditorCulture
+  | MediaPickerEditor
+  | MediaPickerEditorCulture
+  | MemberGroupPickerEditor
+  | MemberGroupPickerEditorCulture
+  | MemberPickerEditor
+  | MemberPickerEditorCulture
+  | MultinodeTreepickerEditor
+  | MultinodeTreepickerEditorCulture
+  | MultiUrlPickerEditor
+  | MultiUrlPickerEditorCulture
+  | NumericEditor
+  | NumericEditorCulture
+  | RadioboxEditor
+  | RadioboxEditorCulture
+  | RepeatableTextstringsEditor
+  | RepeatableTextstringsEditorCulture
+  | RichtextEditor
+  | RichtextEditorCulture
+  | SiteWithCulture
+  | SliderEditor
+  | SliderEditorCulture
+  | TagsEditor
+  | TagsEditorCulture
+  | TextareaEditor
+  | TextareaEditorCulture
+  | TextboxEditor
+  | TextboxEditorCulture
+  | ToggleEditor
+  | ToggleEditorCulture
+  | UmbBlockGridDemoHeadlineBlock
+  | UmbBlockGridDemoImageBlock
+  | UmbBlockGridDemoRichTextBlock
+  | UserPickerEditor
+  | UserPickerEditorCulture
+  | BlockGridEditor1
+  | Image
+  | File
+  | UmbracoMediaVideo
+  | UmbracoMediaAudio
+  | UmbracoMediaArticle
+  | UmbracoMediaVectorGraphics
+  | CustomMediaType
+  | Member
+  | TestMember
 
 "Used to get typed properties on a nested content property"
-union TypedNestedContentProperties = EmptyPropertyType | BlockGridEditor | BlockListEditor | BlockListEditorCulture | CheckboxListEditor | CheckboxListEditorCulture | ColorPickerEditor | ColorPickerEditorCulture | ContentPickerEditor | ContentPickerEditorCulture | DatePickerEditor | DatePickerEditorCulture | DecimalEditor | DecimalEditorCulture | Default | DefaultCulture | DropdownEditor | DropdownEditorCulture | EmailAddressEditor | EmailAddressEditorCulture | EyeDropperColorPickerEditor | EyeDropperColorPickerEditorCulture | FileUpload | FileUploadCulture | ImageCropperEditor | ImageCropperEditorCulture | LabelEditor | LabelEditorCulture | MarkdownEditor | MarkdownEditorCulture | MediaPickerEditor | MediaPickerEditorCulture | MemberGroupPickerEditor | MemberGroupPickerEditorCulture | MemberPickerEditor | MemberPickerEditorCulture | MultinodeTreepickerEditor | MultinodeTreepickerEditorCulture | MultiUrlPickerEditor | MultiUrlPickerEditorCulture | NumericEditor | NumericEditorCulture | RadioboxEditor | RadioboxEditorCulture | RepeatableTextstringsEditor | RepeatableTextstringsEditorCulture | RichtextEditor | RichtextEditorCulture | SiteWithCulture | SliderEditor | SliderEditorCulture | TagsEditor | TagsEditorCulture | TextareaEditor | TextareaEditorCulture | TextboxEditor | TextboxEditorCulture | ToggleEditor | ToggleEditorCulture | UmbBlockGridDemoHeadlineBlock | UmbBlockGridDemoImageBlock | UmbBlockGridDemoRichTextBlock | UserPickerEditor | UserPickerEditorCulture | BlockGridEditor1 | Image | File | UmbracoMediaVideo | UmbracoMediaAudio | UmbracoMediaArticle | UmbracoMediaVectorGraphics | CustomMediaType | Member | TestMember
+union TypedNestedContentProperties =
+  | EmptyPropertyType
+  | BlockGridEditor
+  | BlockListEditor
+  | BlockListEditorCulture
+  | CheckboxListEditor
+  | CheckboxListEditorCulture
+  | ColorPickerEditor
+  | ColorPickerEditorCulture
+  | ContentPickerEditor
+  | ContentPickerEditorCulture
+  | DatePickerEditor
+  | DatePickerEditorCulture
+  | DecimalEditor
+  | DecimalEditorCulture
+  | Default
+  | DefaultCulture
+  | DropdownEditor
+  | DropdownEditorCulture
+  | EmailAddressEditor
+  | EmailAddressEditorCulture
+  | EyeDropperColorPickerEditor
+  | EyeDropperColorPickerEditorCulture
+  | FileUpload
+  | FileUploadCulture
+  | ImageCropperEditor
+  | ImageCropperEditorCulture
+  | LabelEditor
+  | LabelEditorCulture
+  | MarkdownEditor
+  | MarkdownEditorCulture
+  | MediaPickerEditor
+  | MediaPickerEditorCulture
+  | MemberGroupPickerEditor
+  | MemberGroupPickerEditorCulture
+  | MemberPickerEditor
+  | MemberPickerEditorCulture
+  | MultinodeTreepickerEditor
+  | MultinodeTreepickerEditorCulture
+  | MultiUrlPickerEditor
+  | MultiUrlPickerEditorCulture
+  | NumericEditor
+  | NumericEditorCulture
+  | RadioboxEditor
+  | RadioboxEditorCulture
+  | RepeatableTextstringsEditor
+  | RepeatableTextstringsEditorCulture
+  | RichtextEditor
+  | RichtextEditorCulture
+  | SiteWithCulture
+  | SliderEditor
+  | SliderEditorCulture
+  | TagsEditor
+  | TagsEditorCulture
+  | TextareaEditor
+  | TextareaEditorCulture
+  | TextboxEditor
+  | TextboxEditorCulture
+  | ToggleEditor
+  | ToggleEditorCulture
+  | UmbBlockGridDemoHeadlineBlock
+  | UmbBlockGridDemoImageBlock
+  | UmbBlockGridDemoRichTextBlock
+  | UserPickerEditor
+  | UserPickerEditorCulture
+  | BlockGridEditor1
+  | Image
+  | File
+  | UmbracoMediaVideo
+  | UmbracoMediaAudio
+  | UmbracoMediaArticle
+  | UmbracoMediaVectorGraphics
+  | CustomMediaType
+  | Member
+  | TestMember
 
 "Used to get typed properties on a model - For nested properties use TypedBlockListContentProperties, TypedBlockListSettingsProperties"
-union TypedProperties = EmptyPropertyType | BlockGridEditor | BlockListEditor | BlockListEditorCulture | CheckboxListEditor | CheckboxListEditorCulture | ColorPickerEditor | ColorPickerEditorCulture | ContentPickerEditor | ContentPickerEditorCulture | DatePickerEditor | DatePickerEditorCulture | DecimalEditor | DecimalEditorCulture | Default | DefaultCulture | DropdownEditor | DropdownEditorCulture | EmailAddressEditor | EmailAddressEditorCulture | EyeDropperColorPickerEditor | EyeDropperColorPickerEditorCulture | FileUpload | FileUploadCulture | ImageCropperEditor | ImageCropperEditorCulture | LabelEditor | LabelEditorCulture | MarkdownEditor | MarkdownEditorCulture | MediaPickerEditor | MediaPickerEditorCulture | MemberGroupPickerEditor | MemberGroupPickerEditorCulture | MemberPickerEditor | MemberPickerEditorCulture | MultinodeTreepickerEditor | MultinodeTreepickerEditorCulture | MultiUrlPickerEditor | MultiUrlPickerEditorCulture | NumericEditor | NumericEditorCulture | RadioboxEditor | RadioboxEditorCulture | RepeatableTextstringsEditor | RepeatableTextstringsEditorCulture | RichtextEditor | RichtextEditorCulture | SiteWithCulture | SliderEditor | SliderEditorCulture | TagsEditor | TagsEditorCulture | TextareaEditor | TextareaEditorCulture | TextboxEditor | TextboxEditorCulture | ToggleEditor | ToggleEditorCulture | UmbBlockGridDemoHeadlineBlock | UmbBlockGridDemoImageBlock | UmbBlockGridDemoRichTextBlock | UserPickerEditor | UserPickerEditorCulture | BlockGridEditor1 | Image | File | UmbracoMediaVideo | UmbracoMediaAudio | UmbracoMediaArticle | UmbracoMediaVectorGraphics | CustomMediaType | Member | TestMember
+union TypedProperties =
+  | EmptyPropertyType
+  | BlockGridEditor
+  | BlockListEditor
+  | BlockListEditorCulture
+  | CheckboxListEditor
+  | CheckboxListEditorCulture
+  | ColorPickerEditor
+  | ColorPickerEditorCulture
+  | ContentPickerEditor
+  | ContentPickerEditorCulture
+  | DatePickerEditor
+  | DatePickerEditorCulture
+  | DecimalEditor
+  | DecimalEditorCulture
+  | Default
+  | DefaultCulture
+  | DropdownEditor
+  | DropdownEditorCulture
+  | EmailAddressEditor
+  | EmailAddressEditorCulture
+  | EyeDropperColorPickerEditor
+  | EyeDropperColorPickerEditorCulture
+  | FileUpload
+  | FileUploadCulture
+  | ImageCropperEditor
+  | ImageCropperEditorCulture
+  | LabelEditor
+  | LabelEditorCulture
+  | MarkdownEditor
+  | MarkdownEditorCulture
+  | MediaPickerEditor
+  | MediaPickerEditorCulture
+  | MemberGroupPickerEditor
+  | MemberGroupPickerEditorCulture
+  | MemberPickerEditor
+  | MemberPickerEditorCulture
+  | MultinodeTreepickerEditor
+  | MultinodeTreepickerEditorCulture
+  | MultiUrlPickerEditor
+  | MultiUrlPickerEditorCulture
+  | NumericEditor
+  | NumericEditorCulture
+  | RadioboxEditor
+  | RadioboxEditorCulture
+  | RepeatableTextstringsEditor
+  | RepeatableTextstringsEditorCulture
+  | RichtextEditor
+  | RichtextEditorCulture
+  | SiteWithCulture
+  | SliderEditor
+  | SliderEditorCulture
+  | TagsEditor
+  | TagsEditorCulture
+  | TextareaEditor
+  | TextareaEditorCulture
+  | TextboxEditor
+  | TextboxEditorCulture
+  | ToggleEditor
+  | ToggleEditorCulture
+  | UmbBlockGridDemoHeadlineBlock
+  | UmbBlockGridDemoImageBlock
+  | UmbBlockGridDemoRichTextBlock
+  | UserPickerEditor
+  | UserPickerEditorCulture
+  | BlockGridEditor1
+  | Image
+  | File
+  | UmbracoMediaVideo
+  | UmbracoMediaAudio
+  | UmbracoMediaArticle
+  | UmbracoMediaVectorGraphics
+  | CustomMediaType
+  | Member
+  | TestMember
 
 "Represents the context of a query."
 input QueryContextInput {
@@ -1417,7 +2037,7 @@ input QueryContextInput {
   fallbacks: [PropertyFallback!]
   "The segment to use on a property value."
   segment: String
-  "The base URL of the request. Example: https:\/\/my-website.com. Used to return the correct URLs on content items"
+  "The base URL of the request. Example: https://my-website.com. Used to return the correct URLs on content items"
   baseUrl: String
 }
 
@@ -1480,21 +2100,21 @@ enum UrlMode {
   AUTO
 }
 
-"The authorize directive."
-directive @authorize("The name of the authorization policy that determines access to the annotated resource." policy: String "Roles that are allowed to access the annotated resource." roles: [String!] "Defines when when the authorize directive shall be applied.By default the authorize directives are applied during the validation phase." apply: ApplyPolicy! = BEFORE_RESOLVER) repeatable on OBJECT | FIELD_DEFINITION
+"The `Any` scalar type represents any valid GraphQL value."
+scalar Any @specifiedBy(url: "https://scalars.graphql.org/chillicream/any.html")
 
-"The `@specifiedBy` directive is used within the type system definition language to provide a URL for specifying the behavior of custom scalar definitions."
-directive @specifiedBy("The specifiedBy URL points to a human-readable specification. This field will only read a result for scalar types." url: String!) on SCALAR
+"The `DateTime` scalar type represents a date and time with time zone offset information."
+scalar DateTime
+  @specifiedBy(url: "https://scalars.graphql.org/chillicream/date-time.html")
 
-scalar Any
-
-"The `DateTime` scalar represents an ISO-8601 compliant date time type."
-scalar DateTime @specifiedBy(url: "https:\/\/www.graphql-scalars.com\/date-time")
-
-"The `Decimal` scalar type represents a decimal floating-point number."
+"The `Decimal` scalar type represents a decimal floating-point number with high precision."
 scalar Decimal
+  @specifiedBy(url: "https://scalars.graphql.org/chillicream/decimal.html")
 
-"The `Long` scalar type represents non-fractional signed whole 64-bit numeric values. Long can represent values between -(2^63) and 2^63 - 1."
+"The `Long` scalar type represents a signed 64-bit integer."
 scalar Long
+  @specifiedBy(url: "https://scalars.graphql.org/chillicream/long.html")
 
-scalar UUID @specifiedBy(url: "https:\/\/tools.ietf.org\/html\/rfc4122")
+"The `UUID` scalar type represents a Universally Unique Identifier (UUID) as defined by RFC 9562."
+scalar UUID
+  @specifiedBy(url: "https://scalars.graphql.org/chillicream/uuid.html")

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/ContentAtRoot/Snaps/ContentAtRoot_Snaps_test-11.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/ContentAtRoot/Snaps/ContentAtRoot_Snaps_test-11.snap
@@ -2,12 +2,6 @@
   "errors": [
     {
       "message": "Page must be greater than or equal to 1 (Parameter \u0027page\u0027)",
-      "locations": [
-        {
-          "line": 10,
-          "column": 3
-        }
-      ],
       "path": [
         "contentAtRoot"
       ]

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/ContentAtRoot/Snaps/ContentAtRoot_Snaps_test-12.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/ContentAtRoot/Snaps/ContentAtRoot_Snaps_test-12.snap
@@ -2,12 +2,6 @@
   "errors": [
     {
       "message": "Page must be greater than or equal to 1 (Parameter \u0027page\u0027)",
-      "locations": [
-        {
-          "line": 10,
-          "column": 3
-        }
-      ],
       "path": [
         "contentAtRoot"
       ]

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/ContentAtRoot/Snaps/ContentAtRoot_Snaps_test-13.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/ContentAtRoot/Snaps/ContentAtRoot_Snaps_test-13.snap
@@ -2,12 +2,6 @@
   "errors": [
     {
       "message": "Page must be greater than or equal to 1 (Parameter \u0027page\u0027)",
-      "locations": [
-        {
-          "line": 10,
-          "column": 3
-        }
-      ],
       "path": [
         "contentAtRoot"
       ]

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/ContentByContentType/Snaps/ContentByContentType_Snaps_test-10.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/ContentByContentType/Snaps/ContentByContentType_Snaps_test-10.snap
@@ -223,7 +223,7 @@
             },
             "colorPicker": {
               "value": {
-                "color": "bf9000",
+                "value": "bf9000",
                 "label": "bf9000"
               },
               "model": "DefaultProperty",
@@ -593,7 +593,7 @@
                     },
                     "colorPicker": {
                       "value": {
-                        "color": "bf9000",
+                        "value": "bf9000",
                         "label": "bf9000"
                       },
                       "model": "DefaultProperty",
@@ -718,7 +718,7 @@
             },
             "colorPicker": {
               "value": {
-                "color": "000000",
+                "value": "000000",
                 "label": "000000"
               },
               "model": "DefaultProperty",
@@ -945,7 +945,7 @@
                     },
                     "colorPicker": {
                       "value": {
-                        "color": "bf9000",
+                        "value": "bf9000",
                         "label": "bf9000"
                       },
                       "model": "DefaultProperty",

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/ContentByContentType/Snaps/ContentByContentType_Snaps_test-11.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/ContentByContentType/Snaps/ContentByContentType_Snaps_test-11.snap
@@ -223,7 +223,7 @@
             },
             "colorPicker": {
               "value": {
-                "color": "bf9000",
+                "value": "bf9000",
                 "label": "bf9000"
               },
               "model": "DefaultProperty",
@@ -593,7 +593,7 @@
                     },
                     "colorPicker": {
                       "value": {
-                        "color": "bf9000",
+                        "value": "bf9000",
                         "label": "bf9000"
                       },
                       "model": "DefaultProperty",
@@ -718,7 +718,7 @@
             },
             "colorPicker": {
               "value": {
-                "color": "000000",
+                "value": "000000",
                 "label": "000000"
               },
               "model": "DefaultProperty",
@@ -945,7 +945,7 @@
                     },
                     "colorPicker": {
                       "value": {
-                        "color": "bf9000",
+                        "value": "bf9000",
                         "label": "bf9000"
                       },
                       "model": "DefaultProperty",

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/ContentByContentType/Snaps/ContentByContentType_Snaps_test-12.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/ContentByContentType/Snaps/ContentByContentType_Snaps_test-12.snap
@@ -2,12 +2,6 @@
   "errors": [
     {
       "message": "Page must be greater than or equal to 1 (Parameter \u0027page\u0027)",
-      "locations": [
-        {
-          "line": 11,
-          "column": 3
-        }
-      ],
       "path": [
         "contentByContentType"
       ]

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/ContentByContentType/Snaps/ContentByContentType_Snaps_test-13.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/ContentByContentType/Snaps/ContentByContentType_Snaps_test-13.snap
@@ -2,12 +2,6 @@
   "errors": [
     {
       "message": "Page must be greater than or equal to 1 (Parameter \u0027page\u0027)",
-      "locations": [
-        {
-          "line": 11,
-          "column": 3
-        }
-      ],
       "path": [
         "contentByContentType"
       ]

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/ContentByContentType/Snaps/ContentByContentType_Snaps_test-14.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/ContentByContentType/Snaps/ContentByContentType_Snaps_test-14.snap
@@ -2,12 +2,6 @@
   "errors": [
     {
       "message": "Page must be greater than or equal to 1 (Parameter \u0027page\u0027)",
-      "locations": [
-        {
-          "line": 11,
-          "column": 3
-        }
-      ],
       "path": [
         "contentByContentType"
       ]

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/ContentByContentType/Snaps/ContentByContentType_Snaps_test-15.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/ContentByContentType/Snaps/ContentByContentType_Snaps_test-15.snap
@@ -2,12 +2,6 @@
   "errors": [
     {
       "message": "The value cannot be an empty string. (Parameter \u0027contentType\u0027)",
-      "locations": [
-        {
-          "line": 11,
-          "column": 3
-        }
-      ],
       "path": [
         "contentByContentType"
       ]

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/ContentByContentType/Snaps/ContentByContentType_Snaps_test-3.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/ContentByContentType/Snaps/ContentByContentType_Snaps_test-3.snap
@@ -223,7 +223,7 @@
             },
             "colorPicker": {
               "value": {
-                "color": "bf9000",
+                "value": "bf9000",
                 "label": "bf9000"
               },
               "model": "DefaultProperty",

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/ContentByContentType/Snaps/ContentByContentType_Snaps_test-4.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/ContentByContentType/Snaps/ContentByContentType_Snaps_test-4.snap
@@ -326,7 +326,7 @@
                     },
                     "colorPicker": {
                       "value": {
-                        "color": "bf9000",
+                        "value": "bf9000",
                         "label": "bf9000"
                       },
                       "model": "DefaultProperty",
@@ -451,7 +451,7 @@
             },
             "colorPicker": {
               "value": {
-                "color": "000000",
+                "value": "000000",
                 "label": "000000"
               },
               "model": "DefaultProperty",
@@ -678,7 +678,7 @@
                     },
                     "colorPicker": {
                       "value": {
-                        "color": "bf9000",
+                        "value": "bf9000",
                         "label": "bf9000"
                       },
                       "model": "DefaultProperty",

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/ContentByContentType/Snaps/ContentByContentType_Snaps_test-5.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/ContentByContentType/Snaps/ContentByContentType_Snaps_test-5.snap
@@ -223,7 +223,7 @@
             },
             "colorPicker": {
               "value": {
-                "color": "bf9000",
+                "value": "bf9000",
                 "label": "bf9000"
               },
               "model": "DefaultProperty",
@@ -593,7 +593,7 @@
                     },
                     "colorPicker": {
                       "value": {
-                        "color": "bf9000",
+                        "value": "bf9000",
                         "label": "bf9000"
                       },
                       "model": "DefaultProperty",
@@ -718,7 +718,7 @@
             },
             "colorPicker": {
               "value": {
-                "color": "000000",
+                "value": "000000",
                 "label": "000000"
               },
               "model": "DefaultProperty",
@@ -945,7 +945,7 @@
                     },
                     "colorPicker": {
                       "value": {
-                        "color": "bf9000",
+                        "value": "bf9000",
                         "label": "bf9000"
                       },
                       "model": "DefaultProperty",
@@ -2989,7 +2989,7 @@
                   "contentProperties": {
                     "colorPicker": {
                       "value": {
-                        "color": "000000",
+                        "value": "000000",
                         "label": "000000"
                       },
                       "model": "DefaultProperty",
@@ -3035,12 +3035,12 @@
                   "settingsAlias": null,
                   "contentProperties": {
                     "datePicker": {
-                      "value": "2023-03-09T00:00:00.000Z",
+                      "value": "2023-03-09T00:00:00Z",
                       "model": "DateTimePicker",
                       "__typename": "DateTimePicker"
                     },
                     "datePickerWithTime": {
-                      "value": "2023-03-21T21:00:00.000Z",
+                      "value": "2023-03-21T21:00:00Z",
                       "model": "DateTimePicker",
                       "__typename": "DateTimePicker"
                     },

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/ContentByContentType/Snaps/ContentByContentType_Snaps_test-7.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/ContentByContentType/Snaps/ContentByContentType_Snaps_test-7.snap
@@ -223,7 +223,7 @@
             },
             "colorPicker": {
               "value": {
-                "color": "bf9000",
+                "value": "bf9000",
                 "label": "bf9000"
               },
               "model": "DefaultProperty",
@@ -593,7 +593,7 @@
                     },
                     "colorPicker": {
                       "value": {
-                        "color": "bf9000",
+                        "value": "bf9000",
                         "label": "bf9000"
                       },
                       "model": "DefaultProperty",
@@ -718,7 +718,7 @@
             },
             "colorPicker": {
               "value": {
-                "color": "000000",
+                "value": "000000",
                 "label": "000000"
               },
               "model": "DefaultProperty",
@@ -945,7 +945,7 @@
                     },
                     "colorPicker": {
                       "value": {
-                        "color": "bf9000",
+                        "value": "bf9000",
                         "label": "bf9000"
                       },
                       "model": "DefaultProperty",

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/ContentByContentType/Snaps/ContentByContentType_Snaps_test-8.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/ContentByContentType/Snaps/ContentByContentType_Snaps_test-8.snap
@@ -223,7 +223,7 @@
             },
             "colorPicker": {
               "value": {
-                "color": "bf9000",
+                "value": "bf9000",
                 "label": "bf9000"
               },
               "model": "DefaultProperty",
@@ -593,7 +593,7 @@
                     },
                     "colorPicker": {
                       "value": {
-                        "color": "bf9000",
+                        "value": "bf9000",
                         "label": "bf9000"
                       },
                       "model": "DefaultProperty",
@@ -718,7 +718,7 @@
             },
             "colorPicker": {
               "value": {
-                "color": "000000",
+                "value": "000000",
                 "label": "000000"
               },
               "model": "DefaultProperty",
@@ -945,7 +945,7 @@
                     },
                     "colorPicker": {
                       "value": {
-                        "color": "bf9000",
+                        "value": "bf9000",
                         "label": "bf9000"
                       },
                       "model": "DefaultProperty",

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/ContentByContentType/Snaps/ContentByContentType_Snaps_test-9.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/ContentByContentType/Snaps/ContentByContentType_Snaps_test-9.snap
@@ -223,7 +223,7 @@
             },
             "colorPicker": {
               "value": {
-                "color": "bf9000",
+                "value": "bf9000",
                 "label": "bf9000"
               },
               "model": "DefaultProperty",
@@ -593,7 +593,7 @@
                     },
                     "colorPicker": {
                       "value": {
-                        "color": "bf9000",
+                        "value": "bf9000",
                         "label": "bf9000"
                       },
                       "model": "DefaultProperty",
@@ -718,7 +718,7 @@
             },
             "colorPicker": {
               "value": {
-                "color": "000000",
+                "value": "000000",
                 "label": "000000"
               },
               "model": "DefaultProperty",
@@ -945,7 +945,7 @@
                     },
                     "colorPicker": {
                       "value": {
-                        "color": "bf9000",
+                        "value": "bf9000",
                         "label": "bf9000"
                       },
                       "model": "DefaultProperty",

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/ContentByGuid/Snaps/ContentByGuid_Snaps_test-7.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/ContentByGuid/Snaps/ContentByGuid_Snaps_test-7.snap
@@ -97,7 +97,7 @@
               "contentProperties": {
                 "colorPicker": {
                   "value": {
-                    "color": "000000",
+                    "value": "000000",
                     "label": "000000"
                   },
                   "model": "DefaultProperty",
@@ -143,12 +143,12 @@
               "settingsAlias": null,
               "contentProperties": {
                 "datePicker": {
-                  "value": "2023-03-09T00:00:00.000Z",
+                  "value": "2023-03-09T00:00:00Z",
                   "model": "DateTimePicker",
                   "__typename": "DateTimePicker"
                 },
                 "datePickerWithTime": {
-                  "value": "2023-03-21T21:00:00.000Z",
+                  "value": "2023-03-21T21:00:00Z",
                   "model": "DateTimePicker",
                   "__typename": "DateTimePicker"
                 },

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/ContentByGuid/Snaps/ContentByGuid_Snaps_test-9.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/ContentByGuid/Snaps/ContentByGuid_Snaps_test-9.snap
@@ -1,7 +1,7 @@
 {
   "errors": [
     {
-      "message": "UUID cannot parse the given literal of type \u0060StringValueNode\u0060.",
+      "message": "UUID cannot coerce the given value JSON element of type \u0060String\u0060 to a runtime value.",
       "path": [
         "key"
       ]

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/ContentById/Snaps/ContentById_Snaps_test-7.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/ContentById/Snaps/ContentById_Snaps_test-7.snap
@@ -97,7 +97,7 @@
               "contentProperties": {
                 "colorPicker": {
                   "value": {
-                    "color": "000000",
+                    "value": "000000",
                     "label": "000000"
                   },
                   "model": "DefaultProperty",
@@ -143,12 +143,12 @@
               "settingsAlias": null,
               "contentProperties": {
                 "datePicker": {
-                  "value": "2023-03-09T00:00:00.000Z",
+                  "value": "2023-03-09T00:00:00Z",
                   "model": "DateTimePicker",
                   "__typename": "DateTimePicker"
                 },
                 "datePickerWithTime": {
-                  "value": "2023-03-21T21:00:00.000Z",
+                  "value": "2023-03-21T21:00:00Z",
                   "model": "DateTimePicker",
                   "__typename": "DateTimePicker"
                 },

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/ContentById/Snaps/ContentById_Snaps_test-9.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/ContentById/Snaps/ContentById_Snaps_test-9.snap
@@ -2,12 +2,6 @@
   "errors": [
     {
       "message": "Id must be greater than 0 (Parameter \u0027id\u0027)",
-      "locations": [
-        {
-          "line": 9,
-          "column": 3
-        }
-      ],
       "path": [
         "contentById"
       ]

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/ContentByRoute/Snaps/ContentByRoute_Snaps_test-2.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/ContentByRoute/Snaps/ContentByRoute_Snaps_test-2.snap
@@ -221,7 +221,7 @@
         },
         "colorPicker": {
           "value": {
-            "color": "bf9000",
+            "value": "bf9000",
             "label": "bf9000"
           },
           "model": "DefaultProperty",

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/ContentByRoute/Snaps/ContentByRoute_Snaps_test-3.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/ContentByRoute/Snaps/ContentByRoute_Snaps_test-3.snap
@@ -324,7 +324,7 @@
                 },
                 "colorPicker": {
                   "value": {
-                    "color": "bf9000",
+                    "value": "bf9000",
                     "label": "bf9000"
                   },
                   "model": "DefaultProperty",
@@ -449,7 +449,7 @@
         },
         "colorPicker": {
           "value": {
-            "color": "000000",
+            "value": "000000",
             "label": "000000"
           },
           "model": "DefaultProperty",
@@ -676,7 +676,7 @@
                 },
                 "colorPicker": {
                   "value": {
-                    "color": "bf9000",
+                    "value": "bf9000",
                     "label": "bf9000"
                   },
                   "model": "DefaultProperty",

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/ContentByRoute/Snaps/ContentByRoute_Snaps_test-5.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/ContentByRoute/Snaps/ContentByRoute_Snaps_test-5.snap
@@ -97,7 +97,7 @@
               "contentProperties": {
                 "colorPicker": {
                   "value": {
-                    "color": "000000",
+                    "value": "000000",
                     "label": "000000"
                   },
                   "model": "DefaultProperty",
@@ -143,12 +143,12 @@
               "settingsAlias": null,
               "contentProperties": {
                 "datePicker": {
-                  "value": "2023-03-09T00:00:00.000Z",
+                  "value": "2023-03-09T00:00:00Z",
                   "model": "DateTimePicker",
                   "__typename": "DateTimePicker"
                 },
                 "datePickerWithTime": {
-                  "value": "2023-03-21T21:00:00.000Z",
+                  "value": "2023-03-21T21:00:00Z",
                   "model": "DateTimePicker",
                   "__typename": "DateTimePicker"
                 },

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/ContentByTag/Snaps/ContentByTag_Snaps_test-1.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/ContentByTag/Snaps/ContentByTag_Snaps_test-1.snap
@@ -350,7 +350,7 @@
                   "contentProperties": {
                     "colorPicker": {
                       "value": {
-                        "color": "f44336",
+                        "value": "f44336",
                         "label": "f44336"
                       },
                       "model": "DefaultProperty",
@@ -530,7 +530,7 @@
             },
             "colorPickerCulture": {
               "value": {
-                "color": "f44336",
+                "value": "f44336",
                 "label": "f44336"
               },
               "model": "DefaultProperty",
@@ -976,7 +976,7 @@
                   "contentProperties": {
                     "colorPicker": {
                       "value": {
-                        "color": "f44336",
+                        "value": "f44336",
                         "label": "f44336"
                       },
                       "model": "DefaultProperty",
@@ -1156,7 +1156,7 @@
             },
             "colorPickerCulture": {
               "value": {
-                "color": "f44336",
+                "value": "f44336",
                 "label": "f44336"
               },
               "model": "DefaultProperty",

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/ContentByTag/Snaps/ContentByTag_Snaps_test-2.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/ContentByTag/Snaps/ContentByTag_Snaps_test-2.snap
@@ -350,7 +350,7 @@
                   "contentProperties": {
                     "colorPicker": {
                       "value": {
-                        "color": "f44336",
+                        "value": "f44336",
                         "label": "f44336"
                       },
                       "model": "DefaultProperty",
@@ -530,7 +530,7 @@
             },
             "colorPickerCulture": {
               "value": {
-                "color": "f44336",
+                "value": "f44336",
                 "label": "f44336"
               },
               "model": "DefaultProperty",
@@ -976,7 +976,7 @@
                   "contentProperties": {
                     "colorPicker": {
                       "value": {
-                        "color": "f44336",
+                        "value": "f44336",
                         "label": "f44336"
                       },
                       "model": "DefaultProperty",
@@ -1156,7 +1156,7 @@
             },
             "colorPickerCulture": {
               "value": {
-                "color": "f44336",
+                "value": "f44336",
                 "label": "f44336"
               },
               "model": "DefaultProperty",

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/ContentByTag/Snaps/ContentByTag_Snaps_test-3.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/ContentByTag/Snaps/ContentByTag_Snaps_test-3.snap
@@ -1478,7 +1478,7 @@
             },
             "colorPickerCulture": {
               "value": {
-                "color": "000000",
+                "value": "000000",
                 "label": "000000"
               },
               "model": "DefaultProperty",

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/FindMembersByDisplayName/Snaps/FindMembersByDisplayName_Snaps_test-1.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/FindMembersByDisplayName/Snaps/FindMembersByDisplayName_Snaps_test-1.snap
@@ -2,12 +2,6 @@
   "errors": [
     {
       "message": "Parameter page and itemsPerPage must be greater then zero.",
-      "locations": [
-        {
-          "line": 7,
-          "column": 3
-        }
-      ],
       "path": [
         "findMembersByDisplayName"
       ]

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/FindMembersByDisplayName/Snaps/FindMembersByDisplayName_Snaps_test-7.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/FindMembersByDisplayName/Snaps/FindMembersByDisplayName_Snaps_test-7.snap
@@ -2,12 +2,6 @@
   "errors": [
     {
       "message": "The page must be greater than or equal to one (Parameter \u0027page\u0027)",
-      "locations": [
-        {
-          "line": 7,
-          "column": 3
-        }
-      ],
       "path": [
         "findMembersByDisplayName"
       ]

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/FindMembersByDisplayName/Snaps/FindMembersByDisplayName_Snaps_test-8.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/FindMembersByDisplayName/Snaps/FindMembersByDisplayName_Snaps_test-8.snap
@@ -2,12 +2,6 @@
   "errors": [
     {
       "message": "The page must be greater than or equal to one (Parameter \u0027page\u0027)",
-      "locations": [
-        {
-          "line": 7,
-          "column": 3
-        }
-      ],
       "path": [
         "findMembersByDisplayName"
       ]

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/FindMembersByDisplayName/Snaps/FindMembersByDisplayName_Snaps_test-9.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/FindMembersByDisplayName/Snaps/FindMembersByDisplayName_Snaps_test-9.snap
@@ -2,12 +2,6 @@
   "errors": [
     {
       "message": "The page must be greater than or equal to one (Parameter \u0027page\u0027)",
-      "locations": [
-        {
-          "line": 7,
-          "column": 3
-        }
-      ],
       "path": [
         "findMembersByDisplayName"
       ]

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/FindMembersByEmail/Snaps/FindMembersByEmail_Snaps_test-1.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/FindMembersByEmail/Snaps/FindMembersByEmail_Snaps_test-1.snap
@@ -2,12 +2,6 @@
   "errors": [
     {
       "message": "Parameter page and itemsPerPage must be greater then zero.",
-      "locations": [
-        {
-          "line": 7,
-          "column": 3
-        }
-      ],
       "path": [
         "findMembersByEmail"
       ]

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/FindMembersByEmail/Snaps/FindMembersByEmail_Snaps_test-7.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/FindMembersByEmail/Snaps/FindMembersByEmail_Snaps_test-7.snap
@@ -2,12 +2,6 @@
   "errors": [
     {
       "message": "The page must be greater than or equal to one (Parameter \u0027page\u0027)",
-      "locations": [
-        {
-          "line": 7,
-          "column": 3
-        }
-      ],
       "path": [
         "findMembersByEmail"
       ]

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/FindMembersByEmail/Snaps/FindMembersByEmail_Snaps_test-8.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/FindMembersByEmail/Snaps/FindMembersByEmail_Snaps_test-8.snap
@@ -2,12 +2,6 @@
   "errors": [
     {
       "message": "The page must be greater than or equal to one (Parameter \u0027page\u0027)",
-      "locations": [
-        {
-          "line": 7,
-          "column": 3
-        }
-      ],
       "path": [
         "findMembersByEmail"
       ]

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/FindMembersByEmail/Snaps/FindMembersByEmail_Snaps_test-9.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/FindMembersByEmail/Snaps/FindMembersByEmail_Snaps_test-9.snap
@@ -2,12 +2,6 @@
   "errors": [
     {
       "message": "The page must be greater than or equal to one (Parameter \u0027page\u0027)",
-      "locations": [
-        {
-          "line": 7,
-          "column": 3
-        }
-      ],
       "path": [
         "findMembersByEmail"
       ]

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/FindMembersByRole/Snaps/FindMembersByRole_Snaps_test-10.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/FindMembersByRole/Snaps/FindMembersByRole_Snaps_test-10.snap
@@ -2,12 +2,6 @@
   "errors": [
     {
       "message": "Page must be greater than or equal to 1 (Parameter \u0027page\u0027)",
-      "locations": [
-        {
-          "line": 8,
-          "column": 3
-        }
-      ],
       "path": [
         "findMembersByRole"
       ]

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/FindMembersByRole/Snaps/FindMembersByRole_Snaps_test-11.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/FindMembersByRole/Snaps/FindMembersByRole_Snaps_test-11.snap
@@ -2,12 +2,6 @@
   "errors": [
     {
       "message": "Page must be greater than or equal to 1 (Parameter \u0027page\u0027)",
-      "locations": [
-        {
-          "line": 8,
-          "column": 3
-        }
-      ],
       "path": [
         "findMembersByRole"
       ]

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/FindMembersByRole/Snaps/FindMembersByRole_Snaps_test-9.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/FindMembersByRole/Snaps/FindMembersByRole_Snaps_test-9.snap
@@ -2,12 +2,6 @@
   "errors": [
     {
       "message": "Page must be greater than or equal to 1 (Parameter \u0027page\u0027)",
-      "locations": [
-        {
-          "line": 8,
-          "column": 3
-        }
-      ],
       "path": [
         "findMembersByRole"
       ]

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/FindMembersByUsername/Snaps/FindMembersByUsername_Snaps_test-1.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/FindMembersByUsername/Snaps/FindMembersByUsername_Snaps_test-1.snap
@@ -2,12 +2,6 @@
   "errors": [
     {
       "message": "Parameter page and itemsPerPage must be greater then zero.",
-      "locations": [
-        {
-          "line": 7,
-          "column": 3
-        }
-      ],
       "path": [
         "findMembersByUsername"
       ]

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/FindMembersByUsername/Snaps/FindMembersByUsername_Snaps_test-7.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/FindMembersByUsername/Snaps/FindMembersByUsername_Snaps_test-7.snap
@@ -2,12 +2,6 @@
   "errors": [
     {
       "message": "The page must be greater than or equal to one (Parameter \u0027page\u0027)",
-      "locations": [
-        {
-          "line": 7,
-          "column": 3
-        }
-      ],
       "path": [
         "findMembersByUsername"
       ]

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/FindMembersByUsername/Snaps/FindMembersByUsername_Snaps_test-8.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/FindMembersByUsername/Snaps/FindMembersByUsername_Snaps_test-8.snap
@@ -2,12 +2,6 @@
   "errors": [
     {
       "message": "The page must be greater than or equal to one (Parameter \u0027page\u0027)",
-      "locations": [
-        {
-          "line": 7,
-          "column": 3
-        }
-      ],
       "path": [
         "findMembersByUsername"
       ]

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/FindMembersByUsername/Snaps/FindMembersByUsername_Snaps_test-9.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/FindMembersByUsername/Snaps/FindMembersByUsername_Snaps_test-9.snap
@@ -2,12 +2,6 @@
   "errors": [
     {
       "message": "The page must be greater than or equal to one (Parameter \u0027page\u0027)",
-      "locations": [
-        {
-          "line": 7,
-          "column": 3
-        }
-      ],
       "path": [
         "findMembersByUsername"
       ]

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/MediaAtRoot/Snaps/MediaAtRoot_Snaps_test-4.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/MediaAtRoot/Snaps/MediaAtRoot_Snaps_test-4.snap
@@ -287,7 +287,7 @@
               "__typename": "ContentPicker"
             },
             "datePickerWithTime": {
-              "value": "2023-04-25T12:00:00.000Z",
+              "value": "2023-04-25T12:00:00Z",
               "model": "DateTimePicker",
               "__typename": "DateTimePicker"
             },

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/MediaAtRoot/Snaps/MediaAtRoot_Snaps_test-7.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/MediaAtRoot/Snaps/MediaAtRoot_Snaps_test-7.snap
@@ -2,12 +2,6 @@
   "errors": [
     {
       "message": "Page must be greater than or equal to 1 (Parameter \u0027page\u0027)",
-      "locations": [
-        {
-          "line": 5,
-          "column": 3
-        }
-      ],
       "path": [
         "mediaAtRoot"
       ]

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/MediaAtRoot/Snaps/MediaAtRoot_Snaps_test-8.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/MediaAtRoot/Snaps/MediaAtRoot_Snaps_test-8.snap
@@ -2,12 +2,6 @@
   "errors": [
     {
       "message": "Page must be greater than or equal to 1 (Parameter \u0027page\u0027)",
-      "locations": [
-        {
-          "line": 5,
-          "column": 3
-        }
-      ],
       "path": [
         "mediaAtRoot"
       ]

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/MediaAtRoot/Snaps/MediaAtRoot_Snaps_test-9.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/MediaAtRoot/Snaps/MediaAtRoot_Snaps_test-9.snap
@@ -2,12 +2,6 @@
   "errors": [
     {
       "message": "Page must be greater than or equal to 1 (Parameter \u0027page\u0027)",
-      "locations": [
-        {
-          "line": 5,
-          "column": 3
-        }
-      ],
       "path": [
         "mediaAtRoot"
       ]

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/MediaByContentType/Snaps/MediaByContentType_Snaps_test-10.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/MediaByContentType/Snaps/MediaByContentType_Snaps_test-10.snap
@@ -2,12 +2,6 @@
   "errors": [
     {
       "message": "Page must be greater than or equal to 1 (Parameter \u0027page\u0027)",
-      "locations": [
-        {
-          "line": 6,
-          "column": 3
-        }
-      ],
       "path": [
         "mediaByContentType"
       ]

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/MediaByContentType/Snaps/MediaByContentType_Snaps_test-11.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/MediaByContentType/Snaps/MediaByContentType_Snaps_test-11.snap
@@ -2,12 +2,6 @@
   "errors": [
     {
       "message": "Page must be greater than or equal to 1 (Parameter \u0027page\u0027)",
-      "locations": [
-        {
-          "line": 6,
-          "column": 3
-        }
-      ],
       "path": [
         "mediaByContentType"
       ]

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/MediaByContentType/Snaps/MediaByContentType_Snaps_test-12.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/MediaByContentType/Snaps/MediaByContentType_Snaps_test-12.snap
@@ -2,12 +2,6 @@
   "errors": [
     {
       "message": "The value cannot be an empty string. (Parameter \u0027contentType\u0027)",
-      "locations": [
-        {
-          "line": 6,
-          "column": 3
-        }
-      ],
       "path": [
         "mediaByContentType"
       ]

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/MediaByContentType/Snaps/MediaByContentType_Snaps_test-3.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/MediaByContentType/Snaps/MediaByContentType_Snaps_test-3.snap
@@ -222,7 +222,7 @@
               "__typename": "ContentPicker"
             },
             "datePickerWithTime": {
-              "value": "2023-04-25T12:00:00.000Z",
+              "value": "2023-04-25T12:00:00Z",
               "model": "DateTimePicker",
               "__typename": "DateTimePicker"
             },

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/MediaByContentType/Snaps/MediaByContentType_Snaps_test-9.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/MediaByContentType/Snaps/MediaByContentType_Snaps_test-9.snap
@@ -2,12 +2,6 @@
   "errors": [
     {
       "message": "Page must be greater than or equal to 1 (Parameter \u0027page\u0027)",
-      "locations": [
-        {
-          "line": 6,
-          "column": 3
-        }
-      ],
       "path": [
         "mediaByContentType"
       ]

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/MediaByGuid/Snaps/MediaByGuid_Snaps_test-4.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/MediaByGuid/Snaps/MediaByGuid_Snaps_test-4.snap
@@ -220,7 +220,7 @@
           "__typename": "ContentPicker"
         },
         "datePickerWithTime": {
-          "value": "2023-04-25T12:00:00.000Z",
+          "value": "2023-04-25T12:00:00Z",
           "model": "DateTimePicker",
           "__typename": "DateTimePicker"
         },

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/MediaByGuid/Snaps/MediaByGuid_Snaps_test-5.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/MediaByGuid/Snaps/MediaByGuid_Snaps_test-5.snap
@@ -1,7 +1,7 @@
 {
   "errors": [
     {
-      "message": "UUID cannot parse the given literal of type \u0060StringValueNode\u0060.",
+      "message": "UUID cannot coerce the given value JSON element of type \u0060String\u0060 to a runtime value.",
       "path": [
         "key"
       ]

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/MediaById/Snaps/MediaById_Snaps_test-4.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/MediaById/Snaps/MediaById_Snaps_test-4.snap
@@ -220,7 +220,7 @@
           "__typename": "ContentPicker"
         },
         "datePickerWithTime": {
-          "value": "2023-04-25T12:00:00.000Z",
+          "value": "2023-04-25T12:00:00Z",
           "model": "DateTimePicker",
           "__typename": "DateTimePicker"
         },

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/MediaById/Snaps/MediaById_Snaps_test-5.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/MediaById/Snaps/MediaById_Snaps_test-5.snap
@@ -2,12 +2,6 @@
   "errors": [
     {
       "message": "The id must be greater than zero (Parameter \u0027id\u0027)",
-      "locations": [
-        {
-          "line": 2,
-          "column": 3
-        }
-      ],
       "path": [
         "mediaById"
       ]

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/MemberById/Snaps/MemberById_Snaps_test-5.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/MemberById/Snaps/MemberById_Snaps_test-5.snap
@@ -2,12 +2,6 @@
   "errors": [
     {
       "message": "The id must be greater than zero (Parameter \u0027id\u0027)",
-      "locations": [
-        {
-          "line": 4,
-          "column": 3
-        }
-      ],
       "path": [
         "memberById"
       ]

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/MemberById/Snaps/MemberById_Snaps_test-6.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/MemberById/Snaps/MemberById_Snaps_test-6.snap
@@ -2,12 +2,6 @@
   "errors": [
     {
       "message": "The id must be greater than zero (Parameter \u0027id\u0027)",
-      "locations": [
-        {
-          "line": 4,
-          "column": 3
-        }
-      ],
       "path": [
         "memberById"
       ]

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/MemberById/Snaps/MemberById_Snaps_test-7.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/MemberById/Snaps/MemberById_Snaps_test-7.snap
@@ -2,12 +2,6 @@
   "errors": [
     {
       "message": "The id must be greater than zero (Parameter \u0027id\u0027)",
-      "locations": [
-        {
-          "line": 4,
-          "column": 3
-        }
-      ],
       "path": [
         "memberById"
       ]

--- a/src/Nikcio.UHeadless.IntegrationTests/Snapshots/Schema/Schema.snap
+++ b/src/Nikcio.UHeadless.IntegrationTests/Snapshots/Schema/Schema.snap
@@ -2,6 +2,1042 @@ schema {
   query: Query
 }
 
+"The base query object"
+type Query {
+  "Gets a content item by a route."
+  contentByRoute(
+    "The route to fetch. Example '/da/frontpage/'."
+    route: String!
+    "The context of the request."
+    inContext: QueryContextInput
+  ): ContentItem
+  "Gets all the content items by content type."
+  contentByContentType(
+    "The contentType to fetch."
+    contentType: String!
+    "How many items to include in a page. Defaults to 10."
+    pageSize: Int! = 10
+    "The page number to fetch. Defaults to 1."
+    page: Int! = 1
+    "The context of the request."
+    inContext: QueryContextInput
+  ): PaginationOfContentItem!
+  "Gets all the content items at root level."
+  contentAtRoot(
+    "How many items to include in a page. Defaults to 10."
+    pageSize: Int! = 10
+    "The page number to fetch. Defaults to 1."
+    page: Int! = 1
+    "The context of the request."
+    inContext: QueryContextInput
+  ): PaginationOfContentItem!
+  "Gets a content item by id."
+  contentById(
+    "The id to fetch."
+    id: Int!
+    "The context of the request."
+    inContext: QueryContextInput
+  ): ContentItem
+  "Gets a content item by Guid."
+  contentByGuid(
+    "The id to fetch."
+    id: UUID!
+    "The context of the request."
+    inContext: QueryContextInput
+  ): ContentItem
+  "Gets content items by tag."
+  contentByTag(
+    "The tag to fetch."
+    tag: String!
+    "The tag group to fetch."
+    tagGroup: String
+    "How many items to include in a page. Defaults to 10."
+    pageSize: Int! = 10
+    "The page number to fetch. Defaults to 1."
+    page: Int! = 1
+    "The context of the request."
+    inContext: QueryContextInput
+  ): PaginationOfContentItem!
+  "Gets all the media items by content type."
+  mediaByContentType(
+    "The content type to fetch."
+    contentType: String!
+    "How many items to include in a page. Defaults to 10."
+    pageSize: Int! = 10
+    "The page number to fetch. Defaults to 1."
+    page: Int! = 1
+  ): PaginationOfMediaItem!
+  "Gets all the media items at root level."
+  mediaAtRoot(
+    "How many items to include in a page. Defaults to 10."
+    pageSize: Int! = 10
+    "The page number to fetch. Defaults to 1."
+    page: Int! = 1
+  ): PaginationOfMediaItem!
+  "Gets a Media item by id."
+  mediaById("The id to fetch." id: Int!): MediaItem
+  "Gets a Media item by Guid."
+  mediaByGuid("The Guid to fetch." id: UUID!): MediaItem
+  "Finds members by display name."
+  findMembersByDisplayName(
+    "The display name (may be partial)."
+    displayName: String!
+    "Determines how to match a string property value."
+    matchType: StringPropertyMatchType!
+    "The page number to fetch. Defaults to 1."
+    page: Int! = 1
+    "How many items to include in a page. Defaults to 10."
+    pageSize: Int! = 10
+  ): [MemberItem]!
+  "Finds members by email."
+  findMembersByEmail(
+    "The email (may be partial)."
+    email: String!
+    "Determines how to match a string property value."
+    matchType: StringPropertyMatchType!
+    "The page number to fetch. Defaults to 1."
+    page: Int! = 1
+    "How many items to include in a page. Defaults to 10."
+    pageSize: Int! = 10
+  ): [MemberItem]!
+  "Finds members by role."
+  findMembersByRole(
+    "The role name."
+    roleName: String!
+    "The username to match."
+    usernameToMatch: String!
+    "Determines how to match a string property value."
+    matchType: StringPropertyMatchType!
+    "How many items to include in a page. Defaults to 10."
+    pageSize: Int! = 10
+    "The page number to fetch. Defaults to 1."
+    page: Int! = 1
+  ): PaginationOfMemberItem!
+  "Finds members by username."
+  findMembersByUsername(
+    "The username (may be partial)."
+    username: String!
+    "Determines how to match a string property value."
+    matchType: StringPropertyMatchType!
+    "The page number to fetch. Defaults to 1."
+    page: Int! = 1
+    "How many items to include in a page. Defaults to 10."
+    pageSize: Int! = 10
+  ): [MemberItem]!
+  "Gets a member by email."
+  memberByEmail("The email to fetch." email: String!): MemberItem
+  "Gets a member by Guid."
+  memberByGuid("The id to fetch." id: UUID!): MemberItem
+  "Gets a member by id."
+  memberById("The id to fetch." id: Int!): MemberItem
+  "Gets a member by username."
+  memberByUsername("The username to fetch." username: String!): MemberItem
+}
+
+"Represents a block grid property value."
+type BlockGrid implements PropertyValue {
+  "Gets the blocks of a block grid model."
+  blocks: [BlockGridItem!]
+  "Gets the number of columns defined for the grid."
+  gridColumns: Int
+  "The model of the property value"
+  model: String!
+}
+
+"Represents a block grid area."
+type BlockGridArea {
+  "Gets the blocks of the block grid area."
+  blocks: [BlockGridItem!]
+  "Gets the alias of the block grid area."
+  alias: String!
+  "Gets the row dimensions of the block."
+  rowSpan: Int!
+  "Gets the column dimensions of the block."
+  columnSpan: Int!
+}
+
+type BlockGridEditor implements IBlockGridEditor {
+  blockGrid: BlockGrid
+}
+
+type BlockGridEditor1 implements IBlockGridEditor1 {
+  blockGrid: BlockGrid
+}
+
+"Represents a block grid item."
+type BlockGridItem {
+  "Gets the content properties of the block grid item."
+  contentProperties: TypedBlockGridContentProperties!
+  "Gets the setting properties of the block grid item."
+  settingsProperties: TypedBlockGridSettingsProperties!
+  "Gets the areas of the block grid item."
+  areas: [BlockGridArea!]!
+  "Gets the alias of the content block grid item."
+  contentAlias: String
+  "Gets the alias of the settings block grid item."
+  settingsAlias: String
+  "Gets the row dimensions of the block."
+  rowSpan: Int!
+  "Gets the column dimensions of the block."
+  columnSpan: Int!
+}
+
+"Represents a block list model."
+type BlockList implements PropertyValue {
+  "Gets the blocks of a block list model."
+  blocks: [BlockListItem!]
+  "The model of the property value"
+  model: String!
+}
+
+type BlockListEditor implements IBlockListEditor {
+  blockList: BlockList
+}
+
+type BlockListEditorCulture implements IBlockListEditorCulture {
+  blockListCulture: BlockList
+}
+
+"Represents a block list item."
+type BlockListItem {
+  "Gets the content properties of the block list item."
+  contentProperties: TypedBlockListContentProperties!
+  "Gets the setting properties of the block list item."
+  settingsProperties: TypedBlockListSettingsProperties!
+  "Gets the alias of the content block list item."
+  contentAlias: String
+  "Gets the alias of the settings block list item."
+  settingsAlias: String
+}
+
+type CheckboxListEditor implements ICheckboxListEditor {
+  checkboxList: DefaultProperty
+}
+
+type CheckboxListEditorCulture implements ICheckboxListEditorCulture {
+  checkboxListCulture: DefaultProperty
+}
+
+type ColorPickerEditor implements IColorPickerEditor {
+  colorPicker: DefaultProperty
+}
+
+type ColorPickerEditorCulture implements IColorPickerEditorCulture {
+  colorPickerCulture: DefaultProperty
+}
+
+type ContentItem {
+  "Gets the url segment of the content item."
+  urlSegment: String
+  "Gets the url of a content item."
+  url(urlMode: UrlMode!): String
+  "Gets the name of a content item."
+  name: String
+  "Gets the parent of the content item."
+  parent: ContentItem
+  "Gets the properties of the content item."
+  properties: TypedProperties!
+  "Gets the id of a content item."
+  id: Int
+  "Gets the key of a content item."
+  key: UUID
+  "Gets the identifier of the template to use to render the content item."
+  templateId: Int
+  "Gets the date the content item was last updated."
+  updateDate: DateTime
+  statusCode: Int!
+  "Gets the redirect information for the content item."
+  redirect: RedirectInfo
+}
+
+"Represents a content picker value."
+type ContentPicker implements PropertyValue {
+  "Gets the content items of a picker."
+  items: [ContentPickerItem!]
+  "The model of the property value"
+  model: String!
+}
+
+type ContentPickerEditor implements IContentPickerEditor {
+  contentPicker: ContentPicker
+}
+
+type ContentPickerEditorCulture implements IContentPickerEditorCulture {
+  contentPickerCulture: ContentPicker
+}
+
+"Represents a content picker item."
+type ContentPickerItem {
+  "Gets the url of a content item."
+  url(urlMode: UrlMode!): String!
+  "Gets the properties of the content item."
+  properties: TypedProperties!
+  "Gets the url segment of the content item."
+  urlSegment: String
+  "Gets the name of a content item."
+  name: String
+  "Gets the id of a content item."
+  id: Int!
+  "Gets the key of a content item."
+  key: UUID!
+}
+
+type CustomMediaType implements ICustomMediaType {
+  approvedColorEditor: DefaultProperty
+  article: DefaultProperty
+  audio: DefaultProperty
+  blockList: BlockList
+  checkboxList: DefaultProperty
+  contentPicker: ContentPicker
+  datePicker: DateTimePicker
+  datePickerWithTime: DateTimePicker
+  decimal: DefaultProperty
+  dropDown: DefaultProperty
+  dropdownMultiple: DefaultProperty
+  emailAddress: DefaultProperty
+  eyeDropperColorPicker: DefaultProperty
+  file: DefaultProperty
+  imageCropper: DefaultProperty
+  imageMediaPicker: MediaPicker
+  markdownEditor: RichText
+  memberGroupPicker: DefaultProperty
+  memberPicker: MemberPicker
+  multinodeTreepicker: ContentPicker
+  multiUrlPicker: MultiUrlPicker
+  numeric: DefaultProperty
+  radiobox: DefaultProperty
+  repeatableTextStrings: DefaultProperty
+  richText: RichText
+  slider: DefaultProperty
+  sVG: DefaultProperty
+  tags: DefaultProperty
+  textarea: DefaultProperty
+  textstring: DefaultProperty
+  toggle: DefaultProperty
+  userPicker: DefaultProperty
+  video: DefaultProperty
+}
+
+type DatePickerEditor implements IDatePickerEditor {
+  datePicker: DateTimePicker
+  datePickerWithTime: DateTimePicker
+}
+
+type DatePickerEditorCulture implements IDatePickerEditorCulture {
+  datePickerCulture: DateTimePicker
+  datePickerWithTimeCulture: DateTimePicker
+}
+
+"Represents a date time property value."
+type DateTimePicker implements PropertyValue {
+  "Gets the value of the property."
+  value: DateTime
+  "The model of the property value"
+  model: String!
+}
+
+type DecimalEditor implements IDecimalEditor {
+  decimal: DefaultProperty
+}
+
+type DecimalEditorCulture implements IDecimalEditorCulture {
+  decimalCulture: DefaultProperty
+}
+
+type Default implements IBlockGridEditor &
+  IBlockListEditor &
+  ICheckboxListEditor &
+  IColorPickerEditor &
+  IContentPickerEditor &
+  IDatePickerEditor &
+  IDecimalEditor &
+  IDropdownEditor &
+  IEmailAddressEditor &
+  IEyeDropperColorPickerEditor &
+  IFileUpload &
+  IImageCropperEditor &
+  IMarkdownEditor &
+  IMediaPickerEditor &
+  IMemberGroupPickerEditor &
+  IMemberPickerEditor &
+  IMultinodeTreepickerEditor &
+  IMultiUrlPickerEditor &
+  INumericEditor &
+  IRadioboxEditor &
+  IRepeatableTextstringsEditor &
+  IRichtextEditor &
+  ISliderEditor &
+  ITagsEditor &
+  ITextareaEditor &
+  ITextboxEditor &
+  IToggleEditor &
+  IUserPickerEditor &
+  IDefault {
+  blockGrid: BlockGrid
+  blockList: BlockList
+  checkboxList: DefaultProperty
+  colorPicker: DefaultProperty
+  contentPicker: ContentPicker
+  datePicker: DateTimePicker
+  datePickerWithTime: DateTimePicker
+  decimal: DefaultProperty
+  dropdown: DefaultProperty
+  emailAddress: DefaultProperty
+  eyeDropperColorPicker: DefaultProperty
+  article: DefaultProperty
+  audio: DefaultProperty
+  file: DefaultProperty
+  svg: DefaultProperty
+  video: DefaultProperty
+  imageCropper: DefaultProperty
+  markdown: RichText
+  imageMediaPicker: MediaPicker
+  mediaPicker: MediaPicker
+  multipleImageMediaPicker: MediaPicker
+  multipleMediaPicker: MediaPicker
+  memberGroupPicker: DefaultProperty
+  memberPicker: MemberPicker
+  multinodeTreepicker: ContentPicker
+  multiUrlPicker: MultiUrlPicker
+  numeric: DefaultProperty
+  radiobox: DefaultProperty
+  repeatableTextstrings: DefaultProperty
+  richtext: RichText
+  slider: DefaultProperty
+  tags: DefaultProperty
+  textarea: DefaultProperty
+  textstring: DefaultProperty
+  trueOrFalse: DefaultProperty
+  userPicker: DefaultProperty
+}
+
+type DefaultCulture implements IBlockListEditor &
+  IBlockListEditorCulture &
+  ICheckboxListEditor &
+  ICheckboxListEditorCulture &
+  IColorPickerEditor &
+  IColorPickerEditorCulture &
+  IContentPickerEditor &
+  IContentPickerEditorCulture &
+  IDatePickerEditor &
+  IDatePickerEditorCulture &
+  IDecimalEditor &
+  IDecimalEditorCulture &
+  IDropdownEditor &
+  IDropdownEditorCulture &
+  IEmailAddressEditor &
+  IEmailAddressEditorCulture &
+  IEyeDropperColorPickerEditor &
+  IEyeDropperColorPickerEditorCulture &
+  IFileUpload &
+  IFileUploadCulture &
+  IImageCropperEditor &
+  IImageCropperEditorCulture &
+  IMarkdownEditor &
+  IMarkdownEditorCulture &
+  IMediaPickerEditor &
+  IMediaPickerEditorCulture &
+  IMemberGroupPickerEditor &
+  IMemberGroupPickerEditorCulture &
+  IMemberPickerEditor &
+  IMemberPickerEditorCulture &
+  IMultinodeTreepickerEditor &
+  IMultinodeTreepickerEditorCulture &
+  IMultiUrlPickerEditor &
+  IMultiUrlPickerEditorCulture &
+  INumericEditor &
+  INumericEditorCulture &
+  IRadioboxEditor &
+  IRadioboxEditorCulture &
+  IRepeatableTextstringsEditor &
+  IRepeatableTextstringsEditorCulture &
+  IRichtextEditor &
+  IRichtextEditorCulture &
+  ISliderEditor &
+  ISliderEditorCulture &
+  ITagsEditor &
+  ITagsEditorCulture &
+  ITextareaEditor &
+  ITextareaEditorCulture &
+  ITextboxEditor &
+  ITextboxEditorCulture &
+  IToggleEditor &
+  IToggleEditorCulture &
+  IUserPickerEditor &
+  IUserPickerEditorCulture &
+  IDefaultCulture {
+  blockList: BlockList
+  blockListCulture: BlockList
+  checkboxList: DefaultProperty
+  checkboxListCulture: DefaultProperty
+  colorPicker: DefaultProperty
+  colorPickerCulture: DefaultProperty
+  contentPicker: ContentPicker
+  contentPickerCulture: ContentPicker
+  datePicker: DateTimePicker
+  datePickerWithTime: DateTimePicker
+  datePickerCulture: DateTimePicker
+  datePickerWithTimeCulture: DateTimePicker
+  decimal: DefaultProperty
+  decimalCulture: DefaultProperty
+  dropdown: DefaultProperty
+  dropdownCulture: DefaultProperty
+  emailAddress: DefaultProperty
+  emailAddressCulture: DefaultProperty
+  eyeDropperColorPicker: DefaultProperty
+  eyeDropperColorPickerCulture: DefaultProperty
+  article: DefaultProperty
+  audio: DefaultProperty
+  file: DefaultProperty
+  svg: DefaultProperty
+  video: DefaultProperty
+  articleCulture: DefaultProperty
+  audioCulture: DefaultProperty
+  fileCulture: DefaultProperty
+  svgCulture: DefaultProperty
+  videoCulture: DefaultProperty
+  imageCropper: DefaultProperty
+  imageCropperCulture: DefaultProperty
+  markdown: RichText
+  markdownCulture: RichText
+  imageMediaPicker: MediaPicker
+  mediaPicker: MediaPicker
+  multipleImageMediaPicker: MediaPicker
+  multipleMediaPicker: MediaPicker
+  imageMediaPickerCulture: MediaPicker
+  mediaPickerCulture: MediaPicker
+  multipleImageMediaPickerCulture: MediaPicker
+  multipleMediaPickerCulture: MediaPicker
+  memberGroupPicker: DefaultProperty
+  memberGroupPickerCulture: DefaultProperty
+  memberPicker: MemberPicker
+  memberPickerCulture: MemberPicker
+  multinodeTreepicker: ContentPicker
+  multinodeTreepickerCulture: ContentPicker
+  multiUrlPicker: MultiUrlPicker
+  multiUrlPickerCulture: MultiUrlPicker
+  numeric: DefaultProperty
+  numericCulture: DefaultProperty
+  radiobox: DefaultProperty
+  radioboxCulture: DefaultProperty
+  repeatableTextstrings: DefaultProperty
+  repeatableTextstringsCulture: DefaultProperty
+  richtext: RichText
+  richtextCulture: RichText
+  slider: DefaultProperty
+  sliderCulture: DefaultProperty
+  tags: DefaultProperty
+  tagsCulture: DefaultProperty
+  textarea: DefaultProperty
+  textareaCulture: DefaultProperty
+  textstring: DefaultProperty
+  textstringCulture: DefaultProperty
+  trueOrFalse: DefaultProperty
+  trueOrFalseCulture: DefaultProperty
+  userPicker: DefaultProperty
+  userPickerCulture: DefaultProperty
+}
+
+"A catch all property value that simply returns the value of the property. This is all that is needed for simple properties that doesn't need any special handling or formatting."
+type DefaultProperty implements PropertyValue {
+  "Gets the value of the property."
+  value: Any
+  "The model of the property value"
+  model: String!
+}
+
+type DropdownEditor implements IDropdownEditor {
+  dropdown: DefaultProperty
+}
+
+type DropdownEditorCulture implements IDropdownEditorCulture {
+  dropdownCulture: DefaultProperty
+}
+
+type EmailAddressEditor implements IEmailAddressEditor {
+  emailAddress: DefaultProperty
+}
+
+type EmailAddressEditorCulture implements IEmailAddressEditorCulture {
+  emailAddressCulture: DefaultProperty
+}
+
+"Represents a content type that doesn't have any properties and therefore needs a placeholder"
+type EmptyPropertyType {
+  "Placeholder field. Will never hold a value."
+  Empty_Field: String!
+}
+
+type EyeDropperColorPickerEditor implements IEyeDropperColorPickerEditor {
+  eyeDropperColorPicker: DefaultProperty
+}
+
+type EyeDropperColorPickerEditorCulture implements IEyeDropperColorPickerEditorCulture {
+  eyeDropperColorPickerCulture: DefaultProperty
+}
+
+type File implements IFile {
+  umbracoFile: DefaultProperty
+  umbracoExtension: Label
+  "in bytes"
+  umbracoBytes: Label
+}
+
+type FileUpload implements IFileUpload {
+  article: DefaultProperty
+  audio: DefaultProperty
+  file: DefaultProperty
+  svg: DefaultProperty
+  video: DefaultProperty
+}
+
+type FileUploadCulture implements IFileUploadCulture {
+  articleCulture: DefaultProperty
+  audioCulture: DefaultProperty
+  fileCulture: DefaultProperty
+  svgCulture: DefaultProperty
+  videoCulture: DefaultProperty
+}
+
+"Represents focal point coordinates for an image."
+type FocalPoint {
+  "The left coordinate (0.0 to 1.0)"
+  left: Decimal!
+  "The top coordinate (0.0 to 1.0)"
+  top: Decimal!
+}
+
+type Image implements IImage {
+  umbracoFile: DefaultProperty
+  "in pixels"
+  umbracoWidth: Label
+  "in pixels"
+  umbracoHeight: Label
+  "in bytes"
+  umbracoBytes: Label
+  umbracoExtension: Label
+}
+
+type ImageCropperEditor implements IImageCropperEditor {
+  imageCropper: DefaultProperty
+}
+
+type ImageCropperEditorCulture implements IImageCropperEditorCulture {
+  imageCropperCulture: DefaultProperty
+}
+
+type Label implements PropertyValue {
+  "Gets the value of the property."
+  value: Any
+  "The model of the property value"
+  model: String!
+}
+
+type LabelEditor implements ILabelEditor {
+  bigint: Label
+  datetime: Label
+  decimal: Label
+  integer: Label
+  string: Label
+  time: Label
+}
+
+type LabelEditorCulture implements ILabelEditorCulture {
+  bigintCulture: Label
+  datetimeCulture: Label
+  decimalCulture: Label
+  integerCulture: Label
+  stringCulture: Label
+  timeCulture: Label
+}
+
+type MarkdownEditor implements IMarkdownEditor {
+  markdown: RichText
+}
+
+type MarkdownEditorCulture implements IMarkdownEditorCulture {
+  markdownCulture: RichText
+}
+
+type MediaItem {
+  "Gets the url of a media item."
+  url(urlMode: UrlMode!, propertyAlias: String! = "umbracoFile"): String
+  "Gets the parent of the media item."
+  parent: MediaItem
+  "Gets the properties of the media item."
+  properties: TypedProperties!
+  "Gets the url segment of the media item."
+  urlSegment: String
+  "Gets the name of a media item."
+  name: String
+  "Gets the id of a media item."
+  id: Int
+  "Gets the key of a media item."
+  key: UUID
+  "Gets the identifier of the template to use to render the media item."
+  templateId: Int
+  "Gets the date the media item was last updated."
+  updateDate: DateTime
+}
+
+"Represents a media picker item."
+type MediaPicker implements PropertyValue {
+  "Gets the media items of a picker."
+  mediaItems: [MediaPickerItem!]!
+  "The model of the property value"
+  model: String!
+}
+
+type MediaPickerEditor implements IMediaPickerEditor {
+  imageMediaPicker: MediaPicker
+  mediaPicker: MediaPicker
+  multipleImageMediaPicker: MediaPicker
+  multipleMediaPicker: MediaPicker
+}
+
+type MediaPickerEditorCulture implements IMediaPickerEditorCulture {
+  imageMediaPickerCulture: MediaPicker
+  mediaPickerCulture: MediaPicker
+  multipleImageMediaPickerCulture: MediaPicker
+  multipleMediaPickerCulture: MediaPicker
+}
+
+"Represents a media item."
+type MediaPickerItem {
+  "Gets the url of a media item."
+  url(urlMode: UrlMode!): String!
+  "Gets the focal point of an image."
+  focalPoint: FocalPoint
+  "Gets the properties of the media item."
+  properties: TypedProperties!
+  "Gets the url segment of the media item."
+  urlSegment: String
+  "Gets the name of a media item."
+  name: String
+  "Gets the id of a media item."
+  id: Int!
+  "Gets the key of a media item."
+  key: UUID!
+}
+
+type Member implements IMember {
+  umbracoMemberComments: DefaultProperty
+  umbracoMemberFailedPasswordAttempts: Label
+  umbracoMemberApproved: DefaultProperty
+  umbracoMemberLockedOut: DefaultProperty
+  umbracoMemberLastLockoutDate: Label
+  umbracoMemberLastLogin: Label
+  umbracoMemberLastPasswordChangeDate: Label
+}
+
+type MemberGroupPickerEditor implements IMemberGroupPickerEditor {
+  memberGroupPicker: DefaultProperty
+}
+
+type MemberGroupPickerEditorCulture implements IMemberGroupPickerEditorCulture {
+  memberGroupPickerCulture: DefaultProperty
+}
+
+type MemberItem {
+  "Gets the properties of the member item."
+  properties: TypedProperties!
+  "Gets the name of a member item."
+  name: String
+  "Gets the id of a member item."
+  id: Int
+  "Gets the key of a member item."
+  key: UUID
+  "Gets the identifier of the template to use to render the member item."
+  templateId: Int
+  "Gets the date the member item was last updated."
+  updateDate: DateTime
+}
+
+"Represents a member picker."
+type MemberPicker implements PropertyValue {
+  "Gets the member items of a picker. Requires the property.values.member.picker or global.member.read claim to access"
+  members: [MemberPickerItem!]!
+  "The model of the property value"
+  model: String!
+}
+
+type MemberPickerEditor implements IMemberPickerEditor {
+  memberPicker: MemberPicker
+}
+
+type MemberPickerEditorCulture implements IMemberPickerEditorCulture {
+  memberPickerCulture: MemberPicker
+}
+
+"Represents a member item."
+type MemberPickerItem {
+  "Gets the properties of the member item."
+  properties: TypedProperties!
+  "Gets the name of a member item."
+  name: String
+  "Gets the id of a member item."
+  id: Int!
+  "Gets the key of a member item."
+  key: UUID!
+}
+
+type MultinodeTreepickerEditor implements IMultinodeTreepickerEditor {
+  multinodeTreepicker: ContentPicker
+}
+
+type MultinodeTreepickerEditorCulture implements IMultinodeTreepickerEditorCulture {
+  multinodeTreepickerCulture: ContentPicker
+}
+
+"Represents a multi url picker."
+type MultiUrlPicker implements PropertyValue {
+  "Gets the links of the picker."
+  links: [MultiUrlPickerItem!]!
+  "The model of the property value"
+  model: String!
+}
+
+type MultiUrlPickerEditor implements IMultiUrlPickerEditor {
+  multiUrlPicker: MultiUrlPicker
+}
+
+type MultiUrlPickerEditorCulture implements IMultiUrlPickerEditorCulture {
+  multiUrlPickerCulture: MultiUrlPicker
+}
+
+"Represents a content item."
+type MultiUrlPickerItem {
+  "Gets the url of a content item. If the link isn't to a content item or media item then the UrlMode doesn't affect the url."
+  url(urlMode: UrlMode!): String!
+  "Gets the properties of the content item."
+  properties: TypedProperties!
+  "Gets the url segment of the content item."
+  urlSegment: String
+  "Gets the target of the link."
+  target: String
+  "Gets the type of the link."
+  type: LinkType!
+  "Gets the title of the link."
+  title: String
+  "Gets the name of a content item."
+  name: String
+  "Gets the id of a content item."
+  id: Int
+  "Gets the key of a content item."
+  key: UUID
+}
+
+"Represents nested content."
+type NestedContent implements PropertyValue {
+  "Gets the elements of a nested content."
+  elements: [NestedContentItem!]!
+  "The model of the property value"
+  model: String!
+}
+
+type NestedContentItem {
+  "Gets the properties of the nested content."
+  properties: TypedNestedContentProperties!
+}
+
+type NumericEditor implements INumericEditor {
+  numeric: DefaultProperty
+}
+
+type NumericEditorCulture implements INumericEditorCulture {
+  numericCulture: DefaultProperty
+}
+
+"Represents a paginated list of items."
+type PaginationOfContentItem {
+  "The page number."
+  page: Int!
+  "The page size"
+  pageSize: Int!
+  "The total number of items."
+  totalItems: Int!
+  "Whether there is a next page."
+  hasNextPage: Boolean!
+  "The items in the paginated list."
+  items: [ContentItem!]!
+}
+
+"Represents a paginated list of items."
+type PaginationOfMediaItem {
+  "The page number."
+  page: Int!
+  "The page size"
+  pageSize: Int!
+  "The total number of items."
+  totalItems: Int!
+  "Whether there is a next page."
+  hasNextPage: Boolean!
+  "The items in the paginated list."
+  items: [MediaItem!]!
+}
+
+"Represents a paginated list of items."
+type PaginationOfMemberItem {
+  "The page number."
+  page: Int!
+  "The page size"
+  pageSize: Int!
+  "The total number of items."
+  totalItems: Int!
+  "Whether there is a next page."
+  hasNextPage: Boolean!
+  "The items in the paginated list."
+  items: [MemberItem!]!
+}
+
+type RadioboxEditor implements IRadioboxEditor {
+  radiobox: DefaultProperty
+}
+
+type RadioboxEditorCulture implements IRadioboxEditorCulture {
+  radioboxCulture: DefaultProperty
+}
+
+type RedirectInfo {
+  redirectUrl: String
+  isPermanent: Boolean!
+}
+
+type RepeatableTextstringsEditor implements IRepeatableTextstringsEditor {
+  repeatableTextstrings: DefaultProperty
+}
+
+type RepeatableTextstringsEditorCulture implements IRepeatableTextstringsEditorCulture {
+  repeatableTextstringsCulture: DefaultProperty
+}
+
+"Represents a rich text editor."
+type RichText implements PropertyValue {
+  "Gets the HTML value of the rich text editor or markdown editor."
+  value: String
+  "Gets the original value of the rich text editor or markdown editor."
+  sourceValue: String
+  "The model of the property value"
+  model: String!
+}
+
+type RichtextEditor implements IRichtextEditor {
+  richtext: RichText
+}
+
+type RichtextEditorCulture implements IRichtextEditorCulture {
+  richtextCulture: RichText
+}
+
+type SiteWithCulture implements ITextboxEditor &
+  ITextboxEditorCulture &
+  ISiteWithCulture {
+  textstring: DefaultProperty
+  textstringCulture: DefaultProperty
+}
+
+type SliderEditor implements ISliderEditor {
+  slider: DefaultProperty
+}
+
+type SliderEditorCulture implements ISliderEditorCulture {
+  sliderCulture: DefaultProperty
+}
+
+type TagsEditor implements ITagsEditor {
+  tags: DefaultProperty
+}
+
+type TagsEditorCulture implements ITagsEditorCulture {
+  tagsCulture: DefaultProperty
+}
+
+type TestMember implements ITestMember {
+  blockList: BlockList
+  nestedContent: MemberPicker
+  umbracoMemberComments: DefaultProperty
+}
+
+type TextareaEditor implements ITextareaEditor {
+  textarea: DefaultProperty
+}
+
+type TextareaEditorCulture implements ITextareaEditorCulture {
+  textareaCulture: DefaultProperty
+}
+
+type TextboxEditor implements ITextboxEditor {
+  textstring: DefaultProperty
+}
+
+type TextboxEditorCulture implements ITextboxEditorCulture {
+  textstringCulture: DefaultProperty
+}
+
+type ToggleEditor implements IToggleEditor {
+  trueOrFalse: DefaultProperty
+}
+
+type ToggleEditorCulture implements IToggleEditorCulture {
+  trueOrFalseCulture: DefaultProperty
+}
+
+type UmbBlockGridDemoHeadlineBlock implements IUmbBlockGridDemoHeadlineBlock {
+  headline: DefaultProperty
+}
+
+type UmbBlockGridDemoImageBlock implements IUmbBlockGridDemoImageBlock {
+  image: MediaPicker
+}
+
+type UmbBlockGridDemoRichTextBlock implements IUmbBlockGridDemoRichTextBlock {
+  richText: RichText
+}
+
+type UmbracoMediaArticle implements IUmbracoMediaArticle {
+  umbracoFile: DefaultProperty
+  umbracoExtension: Label
+  "in bytes"
+  umbracoBytes: Label
+}
+
+type UmbracoMediaAudio implements IUmbracoMediaAudio {
+  umbracoFile: DefaultProperty
+  umbracoExtension: Label
+  "in bytes"
+  umbracoBytes: Label
+}
+
+type UmbracoMediaVectorGraphics implements IUmbracoMediaVectorGraphics {
+  umbracoFile: DefaultProperty
+  umbracoExtension: Label
+  "in bytes"
+  umbracoBytes: Label
+}
+
+type UmbracoMediaVideo implements IUmbracoMediaVideo {
+  umbracoFile: DefaultProperty
+  umbracoExtension: Label
+  "in bytes"
+  umbracoBytes: Label
+}
+
+"Represents an unsupported property value."
+type UnsupportedProperty implements PropertyValue {
+  "Gets the message of the property."
+  message: String!
+  "The model of the property value"
+  model: String!
+}
+
+type UserPickerEditor implements IUserPickerEditor {
+  userPicker: DefaultProperty
+}
+
+type UserPickerEditorCulture implements IUserPickerEditorCulture {
+  userPickerCulture: DefaultProperty
+}
+
 interface IBlockGridEditor {
   blockGrid: BlockGrid
 }
@@ -340,20 +1376,20 @@ interface IMemberPickerEditorCulture {
   memberPickerCulture: MemberPicker
 }
 
-interface IMultiUrlPickerEditor {
-  multiUrlPicker: MultiUrlPicker
-}
-
-interface IMultiUrlPickerEditorCulture {
-  multiUrlPickerCulture: MultiUrlPicker
-}
-
 interface IMultinodeTreepickerEditor {
   multinodeTreepicker: ContentPicker
 }
 
 interface IMultinodeTreepickerEditorCulture {
   multinodeTreepickerCulture: ContentPicker
+}
+
+interface IMultiUrlPickerEditor {
+  multiUrlPicker: MultiUrlPicker
+}
+
+interface IMultiUrlPickerEditorCulture {
+  multiUrlPickerCulture: MultiUrlPicker
 }
 
 interface INumericEditor {
@@ -493,883 +1529,467 @@ interface PropertyValue {
   model: String!
 }
 
-"Represents a block grid property value."
-type BlockGrid implements PropertyValue {
-  "Gets the blocks of a block grid model."
-  blocks: [BlockGridItem!]
-  "Gets the number of columns defined for the grid."
-  gridColumns: Int
-  "The model of the property value"
-  model: String!
-}
-
-"Represents a block grid area."
-type BlockGridArea {
-  "Gets the blocks of the block grid area."
-  blocks: [BlockGridItem!]
-  "Gets the alias of the block grid area."
-  alias: String!
-  "Gets the row dimensions of the block."
-  rowSpan: Int!
-  "Gets the column dimensions of the block."
-  columnSpan: Int!
-}
-
-type BlockGridEditor implements IBlockGridEditor {
-  blockGrid: BlockGrid
-}
-
-type BlockGridEditor1 implements IBlockGridEditor1 {
-  blockGrid: BlockGrid
-}
-
-"Represents a block grid item."
-type BlockGridItem {
-  "Gets the content properties of the block grid item."
-  contentProperties: TypedBlockGridContentProperties!
-  "Gets the setting properties of the block grid item."
-  settingsProperties: TypedBlockGridSettingsProperties!
-  "Gets the areas of the block grid item."
-  areas: [BlockGridArea!]!
-  "Gets the alias of the content block grid item."
-  contentAlias: String
-  "Gets the alias of the settings block grid item."
-  settingsAlias: String
-  "Gets the row dimensions of the block."
-  rowSpan: Int!
-  "Gets the column dimensions of the block."
-  columnSpan: Int!
-}
-
-"Represents a block list model."
-type BlockList implements PropertyValue {
-  "Gets the blocks of a block list model."
-  blocks: [BlockListItem!]
-  "The model of the property value"
-  model: String!
-}
-
-type BlockListEditor implements IBlockListEditor {
-  blockList: BlockList
-}
-
-type BlockListEditorCulture implements IBlockListEditorCulture {
-  blockListCulture: BlockList
-}
-
-"Represents a block list item."
-type BlockListItem {
-  "Gets the content properties of the block list item."
-  contentProperties: TypedBlockListContentProperties!
-  "Gets the setting properties of the block list item."
-  settingsProperties: TypedBlockListSettingsProperties!
-  "Gets the alias of the content block list item."
-  contentAlias: String
-  "Gets the alias of the settings block list item."
-  settingsAlias: String
-}
-
-type CheckboxListEditor implements ICheckboxListEditor {
-  checkboxList: DefaultProperty
-}
-
-type CheckboxListEditorCulture implements ICheckboxListEditorCulture {
-  checkboxListCulture: DefaultProperty
-}
-
-type ColorPickerEditor implements IColorPickerEditor {
-  colorPicker: DefaultProperty
-}
-
-type ColorPickerEditorCulture implements IColorPickerEditorCulture {
-  colorPickerCulture: DefaultProperty
-}
-
-type ContentItem {
-  "Gets the url segment of the content item."
-  urlSegment: String
-  "Gets the url of a content item."
-  url(urlMode: UrlMode!): String
-  "Gets the name of a content item."
-  name: String
-  "Gets the parent of the content item."
-  parent: ContentItem
-  "Gets the properties of the content item."
-  properties: TypedProperties!
-  "Gets the id of a content item."
-  id: Int
-  "Gets the key of a content item."
-  key: UUID
-  "Gets the identifier of the template to use to render the content item."
-  templateId: Int
-  "Gets the date the content item was last updated."
-  updateDate: DateTime
-  statusCode: Int!
-  "Gets the redirect information for the content item."
-  redirect: RedirectInfo
-}
-
-"Represents a content picker value."
-type ContentPicker implements PropertyValue {
-  "Gets the content items of a picker."
-  items: [ContentPickerItem!]
-  "The model of the property value"
-  model: String!
-}
-
-type ContentPickerEditor implements IContentPickerEditor {
-  contentPicker: ContentPicker
-}
-
-type ContentPickerEditorCulture implements IContentPickerEditorCulture {
-  contentPickerCulture: ContentPicker
-}
-
-"Represents a content picker item."
-type ContentPickerItem {
-  "Gets the url of a content item."
-  url(urlMode: UrlMode!): String!
-  "Gets the properties of the content item."
-  properties: TypedProperties!
-  "Gets the url segment of the content item."
-  urlSegment: String
-  "Gets the name of a content item."
-  name: String
-  "Gets the id of a content item."
-  id: Int!
-  "Gets the key of a content item."
-  key: UUID!
-}
-
-type CustomMediaType implements ICustomMediaType {
-  approvedColorEditor: DefaultProperty
-  article: DefaultProperty
-  audio: DefaultProperty
-  blockList: BlockList
-  checkboxList: DefaultProperty
-  contentPicker: ContentPicker
-  datePicker: DateTimePicker
-  datePickerWithTime: DateTimePicker
-  decimal: DefaultProperty
-  dropDown: DefaultProperty
-  dropdownMultiple: DefaultProperty
-  emailAddress: DefaultProperty
-  eyeDropperColorPicker: DefaultProperty
-  file: DefaultProperty
-  imageCropper: DefaultProperty
-  imageMediaPicker: MediaPicker
-  markdownEditor: RichText
-  memberGroupPicker: DefaultProperty
-  memberPicker: MemberPicker
-  multinodeTreepicker: ContentPicker
-  multiUrlPicker: MultiUrlPicker
-  numeric: DefaultProperty
-  radiobox: DefaultProperty
-  repeatableTextStrings: DefaultProperty
-  richText: RichText
-  slider: DefaultProperty
-  sVG: DefaultProperty
-  tags: DefaultProperty
-  textarea: DefaultProperty
-  textstring: DefaultProperty
-  toggle: DefaultProperty
-  userPicker: DefaultProperty
-  video: DefaultProperty
-}
-
-type DatePickerEditor implements IDatePickerEditor {
-  datePicker: DateTimePicker
-  datePickerWithTime: DateTimePicker
-}
-
-type DatePickerEditorCulture implements IDatePickerEditorCulture {
-  datePickerCulture: DateTimePicker
-  datePickerWithTimeCulture: DateTimePicker
-}
-
-"Represents a date time property value."
-type DateTimePicker implements PropertyValue {
-  "Gets the value of the property."
-  value: DateTime
-  "The model of the property value"
-  model: String!
-}
-
-type DecimalEditor implements IDecimalEditor {
-  decimal: DefaultProperty
-}
-
-type DecimalEditorCulture implements IDecimalEditorCulture {
-  decimalCulture: DefaultProperty
-}
-
-type Default implements IBlockGridEditor & IBlockListEditor & ICheckboxListEditor & IColorPickerEditor & IContentPickerEditor & IDatePickerEditor & IDecimalEditor & IDropdownEditor & IEmailAddressEditor & IEyeDropperColorPickerEditor & IFileUpload & IImageCropperEditor & IMarkdownEditor & IMediaPickerEditor & IMemberGroupPickerEditor & IMemberPickerEditor & IMultinodeTreepickerEditor & IMultiUrlPickerEditor & INumericEditor & IRadioboxEditor & IRepeatableTextstringsEditor & IRichtextEditor & ISliderEditor & ITagsEditor & ITextareaEditor & ITextboxEditor & IToggleEditor & IUserPickerEditor & IDefault {
-  blockGrid: BlockGrid
-  blockList: BlockList
-  checkboxList: DefaultProperty
-  colorPicker: DefaultProperty
-  contentPicker: ContentPicker
-  datePicker: DateTimePicker
-  datePickerWithTime: DateTimePicker
-  decimal: DefaultProperty
-  dropdown: DefaultProperty
-  emailAddress: DefaultProperty
-  eyeDropperColorPicker: DefaultProperty
-  article: DefaultProperty
-  audio: DefaultProperty
-  file: DefaultProperty
-  svg: DefaultProperty
-  video: DefaultProperty
-  imageCropper: DefaultProperty
-  markdown: RichText
-  imageMediaPicker: MediaPicker
-  mediaPicker: MediaPicker
-  multipleImageMediaPicker: MediaPicker
-  multipleMediaPicker: MediaPicker
-  memberGroupPicker: DefaultProperty
-  memberPicker: MemberPicker
-  multinodeTreepicker: ContentPicker
-  multiUrlPicker: MultiUrlPicker
-  numeric: DefaultProperty
-  radiobox: DefaultProperty
-  repeatableTextstrings: DefaultProperty
-  richtext: RichText
-  slider: DefaultProperty
-  tags: DefaultProperty
-  textarea: DefaultProperty
-  textstring: DefaultProperty
-  trueOrFalse: DefaultProperty
-  userPicker: DefaultProperty
-}
-
-type DefaultCulture implements IBlockListEditor & IBlockListEditorCulture & ICheckboxListEditor & ICheckboxListEditorCulture & IColorPickerEditor & IColorPickerEditorCulture & IContentPickerEditor & IContentPickerEditorCulture & IDatePickerEditor & IDatePickerEditorCulture & IDecimalEditor & IDecimalEditorCulture & IDropdownEditor & IDropdownEditorCulture & IEmailAddressEditor & IEmailAddressEditorCulture & IEyeDropperColorPickerEditor & IEyeDropperColorPickerEditorCulture & IFileUpload & IFileUploadCulture & IImageCropperEditor & IImageCropperEditorCulture & IMarkdownEditor & IMarkdownEditorCulture & IMediaPickerEditor & IMediaPickerEditorCulture & IMemberGroupPickerEditor & IMemberGroupPickerEditorCulture & IMemberPickerEditor & IMemberPickerEditorCulture & IMultinodeTreepickerEditor & IMultinodeTreepickerEditorCulture & IMultiUrlPickerEditor & IMultiUrlPickerEditorCulture & INumericEditor & INumericEditorCulture & IRadioboxEditor & IRadioboxEditorCulture & IRepeatableTextstringsEditor & IRepeatableTextstringsEditorCulture & IRichtextEditor & IRichtextEditorCulture & ISliderEditor & ISliderEditorCulture & ITagsEditor & ITagsEditorCulture & ITextareaEditor & ITextareaEditorCulture & ITextboxEditor & ITextboxEditorCulture & IToggleEditor & IToggleEditorCulture & IUserPickerEditor & IUserPickerEditorCulture & IDefaultCulture {
-  blockList: BlockList
-  blockListCulture: BlockList
-  checkboxList: DefaultProperty
-  checkboxListCulture: DefaultProperty
-  colorPicker: DefaultProperty
-  colorPickerCulture: DefaultProperty
-  contentPicker: ContentPicker
-  contentPickerCulture: ContentPicker
-  datePicker: DateTimePicker
-  datePickerWithTime: DateTimePicker
-  datePickerCulture: DateTimePicker
-  datePickerWithTimeCulture: DateTimePicker
-  decimal: DefaultProperty
-  decimalCulture: DefaultProperty
-  dropdown: DefaultProperty
-  dropdownCulture: DefaultProperty
-  emailAddress: DefaultProperty
-  emailAddressCulture: DefaultProperty
-  eyeDropperColorPicker: DefaultProperty
-  eyeDropperColorPickerCulture: DefaultProperty
-  article: DefaultProperty
-  audio: DefaultProperty
-  file: DefaultProperty
-  svg: DefaultProperty
-  video: DefaultProperty
-  articleCulture: DefaultProperty
-  audioCulture: DefaultProperty
-  fileCulture: DefaultProperty
-  svgCulture: DefaultProperty
-  videoCulture: DefaultProperty
-  imageCropper: DefaultProperty
-  imageCropperCulture: DefaultProperty
-  markdown: RichText
-  markdownCulture: RichText
-  imageMediaPicker: MediaPicker
-  mediaPicker: MediaPicker
-  multipleImageMediaPicker: MediaPicker
-  multipleMediaPicker: MediaPicker
-  imageMediaPickerCulture: MediaPicker
-  mediaPickerCulture: MediaPicker
-  multipleImageMediaPickerCulture: MediaPicker
-  multipleMediaPickerCulture: MediaPicker
-  memberGroupPicker: DefaultProperty
-  memberGroupPickerCulture: DefaultProperty
-  memberPicker: MemberPicker
-  memberPickerCulture: MemberPicker
-  multinodeTreepicker: ContentPicker
-  multinodeTreepickerCulture: ContentPicker
-  multiUrlPicker: MultiUrlPicker
-  multiUrlPickerCulture: MultiUrlPicker
-  numeric: DefaultProperty
-  numericCulture: DefaultProperty
-  radiobox: DefaultProperty
-  radioboxCulture: DefaultProperty
-  repeatableTextstrings: DefaultProperty
-  repeatableTextstringsCulture: DefaultProperty
-  richtext: RichText
-  richtextCulture: RichText
-  slider: DefaultProperty
-  sliderCulture: DefaultProperty
-  tags: DefaultProperty
-  tagsCulture: DefaultProperty
-  textarea: DefaultProperty
-  textareaCulture: DefaultProperty
-  textstring: DefaultProperty
-  textstringCulture: DefaultProperty
-  trueOrFalse: DefaultProperty
-  trueOrFalseCulture: DefaultProperty
-  userPicker: DefaultProperty
-  userPickerCulture: DefaultProperty
-}
-
-"A catch all property value that simply returns the value of the property. This is all that is needed for simple properties that doesn't need any special handling or formatting."
-type DefaultProperty implements PropertyValue {
-  "Gets the value of the property."
-  value: Any
-  "The model of the property value"
-  model: String!
-}
-
-type DropdownEditor implements IDropdownEditor {
-  dropdown: DefaultProperty
-}
-
-type DropdownEditorCulture implements IDropdownEditorCulture {
-  dropdownCulture: DefaultProperty
-}
-
-type EmailAddressEditor implements IEmailAddressEditor {
-  emailAddress: DefaultProperty
-}
-
-type EmailAddressEditorCulture implements IEmailAddressEditorCulture {
-  emailAddressCulture: DefaultProperty
-}
-
-"Represents a content type that doesn't have any properties and therefore needs a placeholder"
-type EmptyPropertyType {
-  "Placeholder field. Will never hold a value."
-  Empty_Field: String!
-}
-
-type EyeDropperColorPickerEditor implements IEyeDropperColorPickerEditor {
-  eyeDropperColorPicker: DefaultProperty
-}
-
-type EyeDropperColorPickerEditorCulture implements IEyeDropperColorPickerEditorCulture {
-  eyeDropperColorPickerCulture: DefaultProperty
-}
-
-type File implements IFile {
-  umbracoFile: DefaultProperty
-  umbracoExtension: Label
-  "in bytes"
-  umbracoBytes: Label
-}
-
-type FileUpload implements IFileUpload {
-  article: DefaultProperty
-  audio: DefaultProperty
-  file: DefaultProperty
-  svg: DefaultProperty
-  video: DefaultProperty
-}
-
-type FileUploadCulture implements IFileUploadCulture {
-  articleCulture: DefaultProperty
-  audioCulture: DefaultProperty
-  fileCulture: DefaultProperty
-  svgCulture: DefaultProperty
-  videoCulture: DefaultProperty
-}
-
-"Represents focal point coordinates for an image."
-type FocalPoint {
-  "The left coordinate (0.0 to 1.0)"
-  left: Decimal!
-  "The top coordinate (0.0 to 1.0)"
-  top: Decimal!
-}
-
-type Image implements IImage {
-  umbracoFile: DefaultProperty
-  "in pixels"
-  umbracoWidth: Label
-  "in pixels"
-  umbracoHeight: Label
-  "in bytes"
-  umbracoBytes: Label
-  umbracoExtension: Label
-}
-
-type ImageCropperEditor implements IImageCropperEditor {
-  imageCropper: DefaultProperty
-}
-
-type ImageCropperEditorCulture implements IImageCropperEditorCulture {
-  imageCropperCulture: DefaultProperty
-}
-
-type Label implements PropertyValue {
-  "Gets the value of the property."
-  value: Any
-  "The model of the property value"
-  model: String!
-}
-
-type LabelEditor implements ILabelEditor {
-  bigint: Label
-  datetime: Label
-  decimal: Label
-  integer: Label
-  string: Label
-  time: Label
-}
-
-type LabelEditorCulture implements ILabelEditorCulture {
-  bigintCulture: Label
-  datetimeCulture: Label
-  decimalCulture: Label
-  integerCulture: Label
-  stringCulture: Label
-  timeCulture: Label
-}
-
-type MarkdownEditor implements IMarkdownEditor {
-  markdown: RichText
-}
-
-type MarkdownEditorCulture implements IMarkdownEditorCulture {
-  markdownCulture: RichText
-}
-
-type MediaItem {
-  "Gets the url of a media item."
-  url(urlMode: UrlMode! propertyAlias: String! = "umbracoFile"): String
-  "Gets the parent of the media item."
-  parent: MediaItem
-  "Gets the properties of the media item."
-  properties: TypedProperties!
-  "Gets the url segment of the media item."
-  urlSegment: String
-  "Gets the name of a media item."
-  name: String
-  "Gets the id of a media item."
-  id: Int
-  "Gets the key of a media item."
-  key: UUID
-  "Gets the identifier of the template to use to render the media item."
-  templateId: Int
-  "Gets the date the media item was last updated."
-  updateDate: DateTime
-}
-
-"Represents a media picker item."
-type MediaPicker implements PropertyValue {
-  "Gets the media items of a picker."
-  mediaItems: [MediaPickerItem!]!
-  "The model of the property value"
-  model: String!
-}
-
-type MediaPickerEditor implements IMediaPickerEditor {
-  imageMediaPicker: MediaPicker
-  mediaPicker: MediaPicker
-  multipleImageMediaPicker: MediaPicker
-  multipleMediaPicker: MediaPicker
-}
-
-type MediaPickerEditorCulture implements IMediaPickerEditorCulture {
-  imageMediaPickerCulture: MediaPicker
-  mediaPickerCulture: MediaPicker
-  multipleImageMediaPickerCulture: MediaPicker
-  multipleMediaPickerCulture: MediaPicker
-}
-
-"Represents a media item."
-type MediaPickerItem {
-  "Gets the url of a media item."
-  url(urlMode: UrlMode!): String!
-  "Gets the focal point of an image."
-  focalPoint: FocalPoint
-  "Gets the properties of the media item."
-  properties: TypedProperties!
-  "Gets the url segment of the media item."
-  urlSegment: String
-  "Gets the name of a media item."
-  name: String
-  "Gets the id of a media item."
-  id: Int!
-  "Gets the key of a media item."
-  key: UUID!
-}
-
-type Member implements IMember {
-  umbracoMemberComments: DefaultProperty
-  umbracoMemberFailedPasswordAttempts: Label
-  umbracoMemberApproved: DefaultProperty
-  umbracoMemberLockedOut: DefaultProperty
-  umbracoMemberLastLockoutDate: Label
-  umbracoMemberLastLogin: Label
-  umbracoMemberLastPasswordChangeDate: Label
-}
-
-type MemberGroupPickerEditor implements IMemberGroupPickerEditor {
-  memberGroupPicker: DefaultProperty
-}
-
-type MemberGroupPickerEditorCulture implements IMemberGroupPickerEditorCulture {
-  memberGroupPickerCulture: DefaultProperty
-}
-
-type MemberItem {
-  "Gets the properties of the member item."
-  properties: TypedProperties!
-  "Gets the name of a member item."
-  name: String
-  "Gets the id of a member item."
-  id: Int
-  "Gets the key of a member item."
-  key: UUID
-  "Gets the identifier of the template to use to render the member item."
-  templateId: Int
-  "Gets the date the member item was last updated."
-  updateDate: DateTime
-}
-
-"Represents a member picker."
-type MemberPicker implements PropertyValue {
-  "Gets the member items of a picker. Requires the property.values.member.picker or global.member.read claim to access"
-  members: [MemberPickerItem!]! @authorize(policy: "PropertyValuesMemberPicker")
-  "The model of the property value"
-  model: String!
-}
-
-type MemberPickerEditor implements IMemberPickerEditor {
-  memberPicker: MemberPicker
-}
-
-type MemberPickerEditorCulture implements IMemberPickerEditorCulture {
-  memberPickerCulture: MemberPicker
-}
-
-"Represents a member item."
-type MemberPickerItem {
-  "Gets the properties of the member item."
-  properties: TypedProperties!
-  "Gets the name of a member item."
-  name: String
-  "Gets the id of a member item."
-  id: Int!
-  "Gets the key of a member item."
-  key: UUID!
-}
-
-"Represents a multi url picker."
-type MultiUrlPicker implements PropertyValue {
-  "Gets the links of the picker."
-  links: [MultiUrlPickerItem!]!
-  "The model of the property value"
-  model: String!
-}
-
-type MultiUrlPickerEditor implements IMultiUrlPickerEditor {
-  multiUrlPicker: MultiUrlPicker
-}
-
-type MultiUrlPickerEditorCulture implements IMultiUrlPickerEditorCulture {
-  multiUrlPickerCulture: MultiUrlPicker
-}
-
-"Represents a content item."
-type MultiUrlPickerItem {
-  "Gets the url of a content item. If the link isn't to a content item or media item then the UrlMode doesn't affect the url."
-  url(urlMode: UrlMode!): String!
-  "Gets the properties of the content item."
-  properties: TypedProperties!
-  "Gets the url segment of the content item."
-  urlSegment: String
-  "Gets the target of the link."
-  target: String
-  "Gets the type of the link."
-  type: LinkType!
-  "Gets the title of the link."
-  title: String
-  "Gets the name of a content item."
-  name: String
-  "Gets the id of a content item."
-  id: Int
-  "Gets the key of a content item."
-  key: UUID
-}
-
-type MultinodeTreepickerEditor implements IMultinodeTreepickerEditor {
-  multinodeTreepicker: ContentPicker
-}
-
-type MultinodeTreepickerEditorCulture implements IMultinodeTreepickerEditorCulture {
-  multinodeTreepickerCulture: ContentPicker
-}
-
-"Represents nested content."
-type NestedContent implements PropertyValue {
-  "Gets the elements of a nested content."
-  elements: [NestedContentItem!]!
-  "The model of the property value"
-  model: String!
-}
-
-type NestedContentItem {
-  "Gets the properties of the nested content."
-  properties: TypedNestedContentProperties!
-}
-
-type NumericEditor implements INumericEditor {
-  numeric: DefaultProperty
-}
-
-type NumericEditorCulture implements INumericEditorCulture {
-  numericCulture: DefaultProperty
-}
-
-"Represents a paginated list of items."
-type PaginationOfContentItem {
-  "The page number."
-  page: Int!
-  "The page size"
-  pageSize: Int!
-  "The total number of items."
-  totalItems: Int!
-  "Whether there is a next page."
-  hasNextPage: Boolean!
-  "The items in the paginated list."
-  items: [ContentItem!]!
-}
-
-"Represents a paginated list of items."
-type PaginationOfMediaItem {
-  "The page number."
-  page: Int!
-  "The page size"
-  pageSize: Int!
-  "The total number of items."
-  totalItems: Int!
-  "Whether there is a next page."
-  hasNextPage: Boolean!
-  "The items in the paginated list."
-  items: [MediaItem!]!
-}
-
-"Represents a paginated list of items."
-type PaginationOfMemberItem {
-  "The page number."
-  page: Int!
-  "The page size"
-  pageSize: Int!
-  "The total number of items."
-  totalItems: Int!
-  "Whether there is a next page."
-  hasNextPage: Boolean!
-  "The items in the paginated list."
-  items: [MemberItem!]!
-}
-
-"The base query object"
-type Query {
-  "Gets a content item by a route."
-  contentByRoute("The route to fetch. Example '\/da\/frontpage\/'." route: String! "The context of the request." inContext: QueryContextInput): ContentItem @authorize(policy: "ContentByRouteQuery")
-  "Gets all the content items by content type."
-  contentByContentType("The contentType to fetch." contentType: String! "How many items to include in a page. Defaults to 10." pageSize: Int! = 10 "The page number to fetch. Defaults to 1." page: Int! = 1 "The context of the request." inContext: QueryContextInput): PaginationOfContentItem! @authorize(policy: "ContentByContentTypeQuery")
-  "Gets all the content items at root level."
-  contentAtRoot("How many items to include in a page. Defaults to 10." pageSize: Int! = 10 "The page number to fetch. Defaults to 1." page: Int! = 1 "The context of the request." inContext: QueryContextInput): PaginationOfContentItem! @authorize(policy: "ContentAtRootQuery")
-  "Gets a content item by id."
-  contentById("The id to fetch." id: Int! "The context of the request." inContext: QueryContextInput): ContentItem @authorize(policy: "ContentByIdQuery")
-  "Gets a content item by Guid."
-  contentByGuid("The id to fetch." id: UUID! "The context of the request." inContext: QueryContextInput): ContentItem @authorize(policy: "ContentByGuidQuery")
-  "Gets content items by tag."
-  contentByTag("The tag to fetch." tag: String! "The tag group to fetch." tagGroup: String "How many items to include in a page. Defaults to 10." pageSize: Int! = 10 "The page number to fetch. Defaults to 1." page: Int! = 1 "The context of the request." inContext: QueryContextInput): PaginationOfContentItem! @authorize(policy: "ContentByTagQuery")
-  "Gets all the media items by content type."
-  mediaByContentType("The content type to fetch." contentType: String! "How many items to include in a page. Defaults to 10." pageSize: Int! = 10 "The page number to fetch. Defaults to 1." page: Int! = 1): PaginationOfMediaItem! @authorize(policy: "MediaByContentTypeQuery")
-  "Gets all the media items at root level."
-  mediaAtRoot("How many items to include in a page. Defaults to 10." pageSize: Int! = 10 "The page number to fetch. Defaults to 1." page: Int! = 1): PaginationOfMediaItem! @authorize(policy: "MediaAtRootQuery")
-  "Gets a Media item by id."
-  mediaById("The id to fetch." id: Int!): MediaItem @authorize(policy: "MediaByIdQuery")
-  "Gets a Media item by Guid."
-  mediaByGuid("The Guid to fetch." id: UUID!): MediaItem @authorize(policy: "MediaByGuidQuery")
-  "Finds members by display name."
-  findMembersByDisplayName("The display name (may be partial)." displayName: String! "Determines how to match a string property value." matchType: StringPropertyMatchType! "The page number to fetch. Defaults to 1." page: Int! = 1 "How many items to include in a page. Defaults to 10." pageSize: Int! = 10): [MemberItem]! @authorize(policy: "FindMembersByDisplayNameQuery")
-  "Finds members by email."
-  findMembersByEmail("The email (may be partial)." email: String! "Determines how to match a string property value." matchType: StringPropertyMatchType! "The page number to fetch. Defaults to 1." page: Int! = 1 "How many items to include in a page. Defaults to 10." pageSize: Int! = 10): [MemberItem]! @authorize(policy: "FindMembersByEmailQuery")
-  "Finds members by role."
-  findMembersByRole("The role name." roleName: String! "The username to match." usernameToMatch: String! "Determines how to match a string property value." matchType: StringPropertyMatchType! "How many items to include in a page. Defaults to 10." pageSize: Int! = 10 "The page number to fetch. Defaults to 1." page: Int! = 1): PaginationOfMemberItem! @authorize(policy: "FindMembersByRoleQuery")
-  "Finds members by username."
-  findMembersByUsername("The username (may be partial)." username: String! "Determines how to match a string property value." matchType: StringPropertyMatchType! "The page number to fetch. Defaults to 1." page: Int! = 1 "How many items to include in a page. Defaults to 10." pageSize: Int! = 10): [MemberItem]! @authorize(policy: "FindMembersByUsernameQuery")
-  "Gets a member by email."
-  memberByEmail("The email to fetch." email: String!): MemberItem @authorize(policy: "MemberByEmailQuery")
-  "Gets a member by Guid."
-  memberByGuid("The id to fetch." id: UUID!): MemberItem @authorize(policy: "MemberByGuidQuery")
-  "Gets a member by id."
-  memberById("The id to fetch." id: Int!): MemberItem @authorize(policy: "MemberByIdQuery")
-  "Gets a member by username."
-  memberByUsername("The username to fetch." username: String!): MemberItem @authorize(policy: "MemberByUsernameQuery")
-}
-
-type RadioboxEditor implements IRadioboxEditor {
-  radiobox: DefaultProperty
-}
-
-type RadioboxEditorCulture implements IRadioboxEditorCulture {
-  radioboxCulture: DefaultProperty
-}
-
-type RedirectInfo {
-  redirectUrl: String
-  isPermanent: Boolean!
-}
-
-type RepeatableTextstringsEditor implements IRepeatableTextstringsEditor {
-  repeatableTextstrings: DefaultProperty
-}
-
-type RepeatableTextstringsEditorCulture implements IRepeatableTextstringsEditorCulture {
-  repeatableTextstringsCulture: DefaultProperty
-}
-
-"Represents a rich text editor."
-type RichText implements PropertyValue {
-  "Gets the HTML value of the rich text editor or markdown editor."
-  value: String
-  "Gets the original value of the rich text editor or markdown editor."
-  sourceValue: String
-  "The model of the property value"
-  model: String!
-}
-
-type RichtextEditor implements IRichtextEditor {
-  richtext: RichText
-}
-
-type RichtextEditorCulture implements IRichtextEditorCulture {
-  richtextCulture: RichText
-}
-
-type SiteWithCulture implements ITextboxEditor & ITextboxEditorCulture & ISiteWithCulture {
-  textstring: DefaultProperty
-  textstringCulture: DefaultProperty
-}
-
-type SliderEditor implements ISliderEditor {
-  slider: DefaultProperty
-}
-
-type SliderEditorCulture implements ISliderEditorCulture {
-  sliderCulture: DefaultProperty
-}
-
-type TagsEditor implements ITagsEditor {
-  tags: DefaultProperty
-}
-
-type TagsEditorCulture implements ITagsEditorCulture {
-  tagsCulture: DefaultProperty
-}
-
-type TestMember implements ITestMember {
-  blockList: BlockList
-  nestedContent: MemberPicker
-  umbracoMemberComments: DefaultProperty
-}
-
-type TextareaEditor implements ITextareaEditor {
-  textarea: DefaultProperty
-}
-
-type TextareaEditorCulture implements ITextareaEditorCulture {
-  textareaCulture: DefaultProperty
-}
-
-type TextboxEditor implements ITextboxEditor {
-  textstring: DefaultProperty
-}
-
-type TextboxEditorCulture implements ITextboxEditorCulture {
-  textstringCulture: DefaultProperty
-}
-
-type ToggleEditor implements IToggleEditor {
-  trueOrFalse: DefaultProperty
-}
-
-type ToggleEditorCulture implements IToggleEditorCulture {
-  trueOrFalseCulture: DefaultProperty
-}
-
-type UmbBlockGridDemoHeadlineBlock implements IUmbBlockGridDemoHeadlineBlock {
-  headline: DefaultProperty
-}
-
-type UmbBlockGridDemoImageBlock implements IUmbBlockGridDemoImageBlock {
-  image: MediaPicker
-}
-
-type UmbBlockGridDemoRichTextBlock implements IUmbBlockGridDemoRichTextBlock {
-  richText: RichText
-}
-
-type UmbracoMediaArticle implements IUmbracoMediaArticle {
-  umbracoFile: DefaultProperty
-  umbracoExtension: Label
-  "in bytes"
-  umbracoBytes: Label
-}
-
-type UmbracoMediaAudio implements IUmbracoMediaAudio {
-  umbracoFile: DefaultProperty
-  umbracoExtension: Label
-  "in bytes"
-  umbracoBytes: Label
-}
-
-type UmbracoMediaVectorGraphics implements IUmbracoMediaVectorGraphics {
-  umbracoFile: DefaultProperty
-  umbracoExtension: Label
-  "in bytes"
-  umbracoBytes: Label
-}
-
-type UmbracoMediaVideo implements IUmbracoMediaVideo {
-  umbracoFile: DefaultProperty
-  umbracoExtension: Label
-  "in bytes"
-  umbracoBytes: Label
-}
-
-"Represents an unsupported property value."
-type UnsupportedProperty implements PropertyValue {
-  "Gets the message of the property."
-  message: String!
-  "The model of the property value"
-  model: String!
-}
-
-type UserPickerEditor implements IUserPickerEditor {
-  userPicker: DefaultProperty
-}
-
-type UserPickerEditorCulture implements IUserPickerEditorCulture {
-  userPickerCulture: DefaultProperty
-}
-
 "Used to get typed properties on a block grid property for the content property"
-union TypedBlockGridContentProperties = EmptyPropertyType | BlockGridEditor | BlockListEditor | BlockListEditorCulture | CheckboxListEditor | CheckboxListEditorCulture | ColorPickerEditor | ColorPickerEditorCulture | ContentPickerEditor | ContentPickerEditorCulture | DatePickerEditor | DatePickerEditorCulture | DecimalEditor | DecimalEditorCulture | Default | DefaultCulture | DropdownEditor | DropdownEditorCulture | EmailAddressEditor | EmailAddressEditorCulture | EyeDropperColorPickerEditor | EyeDropperColorPickerEditorCulture | FileUpload | FileUploadCulture | ImageCropperEditor | ImageCropperEditorCulture | LabelEditor | LabelEditorCulture | MarkdownEditor | MarkdownEditorCulture | MediaPickerEditor | MediaPickerEditorCulture | MemberGroupPickerEditor | MemberGroupPickerEditorCulture | MemberPickerEditor | MemberPickerEditorCulture | MultinodeTreepickerEditor | MultinodeTreepickerEditorCulture | MultiUrlPickerEditor | MultiUrlPickerEditorCulture | NumericEditor | NumericEditorCulture | RadioboxEditor | RadioboxEditorCulture | RepeatableTextstringsEditor | RepeatableTextstringsEditorCulture | RichtextEditor | RichtextEditorCulture | SiteWithCulture | SliderEditor | SliderEditorCulture | TagsEditor | TagsEditorCulture | TextareaEditor | TextareaEditorCulture | TextboxEditor | TextboxEditorCulture | ToggleEditor | ToggleEditorCulture | UmbBlockGridDemoHeadlineBlock | UmbBlockGridDemoImageBlock | UmbBlockGridDemoRichTextBlock | UserPickerEditor | UserPickerEditorCulture | BlockGridEditor1 | Image | File | UmbracoMediaVideo | UmbracoMediaAudio | UmbracoMediaArticle | UmbracoMediaVectorGraphics | CustomMediaType | Member | TestMember
+union TypedBlockGridContentProperties =
+  | EmptyPropertyType
+  | BlockGridEditor
+  | BlockListEditor
+  | BlockListEditorCulture
+  | CheckboxListEditor
+  | CheckboxListEditorCulture
+  | ColorPickerEditor
+  | ColorPickerEditorCulture
+  | ContentPickerEditor
+  | ContentPickerEditorCulture
+  | DatePickerEditor
+  | DatePickerEditorCulture
+  | DecimalEditor
+  | DecimalEditorCulture
+  | Default
+  | DefaultCulture
+  | DropdownEditor
+  | DropdownEditorCulture
+  | EmailAddressEditor
+  | EmailAddressEditorCulture
+  | EyeDropperColorPickerEditor
+  | EyeDropperColorPickerEditorCulture
+  | FileUpload
+  | FileUploadCulture
+  | ImageCropperEditor
+  | ImageCropperEditorCulture
+  | LabelEditor
+  | LabelEditorCulture
+  | MarkdownEditor
+  | MarkdownEditorCulture
+  | MediaPickerEditor
+  | MediaPickerEditorCulture
+  | MemberGroupPickerEditor
+  | MemberGroupPickerEditorCulture
+  | MemberPickerEditor
+  | MemberPickerEditorCulture
+  | MultinodeTreepickerEditor
+  | MultinodeTreepickerEditorCulture
+  | MultiUrlPickerEditor
+  | MultiUrlPickerEditorCulture
+  | NumericEditor
+  | NumericEditorCulture
+  | RadioboxEditor
+  | RadioboxEditorCulture
+  | RepeatableTextstringsEditor
+  | RepeatableTextstringsEditorCulture
+  | RichtextEditor
+  | RichtextEditorCulture
+  | SiteWithCulture
+  | SliderEditor
+  | SliderEditorCulture
+  | TagsEditor
+  | TagsEditorCulture
+  | TextareaEditor
+  | TextareaEditorCulture
+  | TextboxEditor
+  | TextboxEditorCulture
+  | ToggleEditor
+  | ToggleEditorCulture
+  | UmbBlockGridDemoHeadlineBlock
+  | UmbBlockGridDemoImageBlock
+  | UmbBlockGridDemoRichTextBlock
+  | UserPickerEditor
+  | UserPickerEditorCulture
+  | BlockGridEditor1
+  | Image
+  | File
+  | UmbracoMediaVideo
+  | UmbracoMediaAudio
+  | UmbracoMediaArticle
+  | UmbracoMediaVectorGraphics
+  | CustomMediaType
+  | Member
+  | TestMember
 
 "Used to get typed properties on a block grid property for the settings property"
-union TypedBlockGridSettingsProperties = EmptyPropertyType | BlockGridEditor | BlockListEditor | BlockListEditorCulture | CheckboxListEditor | CheckboxListEditorCulture | ColorPickerEditor | ColorPickerEditorCulture | ContentPickerEditor | ContentPickerEditorCulture | DatePickerEditor | DatePickerEditorCulture | DecimalEditor | DecimalEditorCulture | Default | DefaultCulture | DropdownEditor | DropdownEditorCulture | EmailAddressEditor | EmailAddressEditorCulture | EyeDropperColorPickerEditor | EyeDropperColorPickerEditorCulture | FileUpload | FileUploadCulture | ImageCropperEditor | ImageCropperEditorCulture | LabelEditor | LabelEditorCulture | MarkdownEditor | MarkdownEditorCulture | MediaPickerEditor | MediaPickerEditorCulture | MemberGroupPickerEditor | MemberGroupPickerEditorCulture | MemberPickerEditor | MemberPickerEditorCulture | MultinodeTreepickerEditor | MultinodeTreepickerEditorCulture | MultiUrlPickerEditor | MultiUrlPickerEditorCulture | NumericEditor | NumericEditorCulture | RadioboxEditor | RadioboxEditorCulture | RepeatableTextstringsEditor | RepeatableTextstringsEditorCulture | RichtextEditor | RichtextEditorCulture | SiteWithCulture | SliderEditor | SliderEditorCulture | TagsEditor | TagsEditorCulture | TextareaEditor | TextareaEditorCulture | TextboxEditor | TextboxEditorCulture | ToggleEditor | ToggleEditorCulture | UmbBlockGridDemoHeadlineBlock | UmbBlockGridDemoImageBlock | UmbBlockGridDemoRichTextBlock | UserPickerEditor | UserPickerEditorCulture | BlockGridEditor1 | Image | File | UmbracoMediaVideo | UmbracoMediaAudio | UmbracoMediaArticle | UmbracoMediaVectorGraphics | CustomMediaType | Member | TestMember
+union TypedBlockGridSettingsProperties =
+  | EmptyPropertyType
+  | BlockGridEditor
+  | BlockListEditor
+  | BlockListEditorCulture
+  | CheckboxListEditor
+  | CheckboxListEditorCulture
+  | ColorPickerEditor
+  | ColorPickerEditorCulture
+  | ContentPickerEditor
+  | ContentPickerEditorCulture
+  | DatePickerEditor
+  | DatePickerEditorCulture
+  | DecimalEditor
+  | DecimalEditorCulture
+  | Default
+  | DefaultCulture
+  | DropdownEditor
+  | DropdownEditorCulture
+  | EmailAddressEditor
+  | EmailAddressEditorCulture
+  | EyeDropperColorPickerEditor
+  | EyeDropperColorPickerEditorCulture
+  | FileUpload
+  | FileUploadCulture
+  | ImageCropperEditor
+  | ImageCropperEditorCulture
+  | LabelEditor
+  | LabelEditorCulture
+  | MarkdownEditor
+  | MarkdownEditorCulture
+  | MediaPickerEditor
+  | MediaPickerEditorCulture
+  | MemberGroupPickerEditor
+  | MemberGroupPickerEditorCulture
+  | MemberPickerEditor
+  | MemberPickerEditorCulture
+  | MultinodeTreepickerEditor
+  | MultinodeTreepickerEditorCulture
+  | MultiUrlPickerEditor
+  | MultiUrlPickerEditorCulture
+  | NumericEditor
+  | NumericEditorCulture
+  | RadioboxEditor
+  | RadioboxEditorCulture
+  | RepeatableTextstringsEditor
+  | RepeatableTextstringsEditorCulture
+  | RichtextEditor
+  | RichtextEditorCulture
+  | SiteWithCulture
+  | SliderEditor
+  | SliderEditorCulture
+  | TagsEditor
+  | TagsEditorCulture
+  | TextareaEditor
+  | TextareaEditorCulture
+  | TextboxEditor
+  | TextboxEditorCulture
+  | ToggleEditor
+  | ToggleEditorCulture
+  | UmbBlockGridDemoHeadlineBlock
+  | UmbBlockGridDemoImageBlock
+  | UmbBlockGridDemoRichTextBlock
+  | UserPickerEditor
+  | UserPickerEditorCulture
+  | BlockGridEditor1
+  | Image
+  | File
+  | UmbracoMediaVideo
+  | UmbracoMediaAudio
+  | UmbracoMediaArticle
+  | UmbracoMediaVectorGraphics
+  | CustomMediaType
+  | Member
+  | TestMember
 
 "Used to get typed properties on a block list property for the content property"
-union TypedBlockListContentProperties = EmptyPropertyType | BlockGridEditor | BlockListEditor | BlockListEditorCulture | CheckboxListEditor | CheckboxListEditorCulture | ColorPickerEditor | ColorPickerEditorCulture | ContentPickerEditor | ContentPickerEditorCulture | DatePickerEditor | DatePickerEditorCulture | DecimalEditor | DecimalEditorCulture | Default | DefaultCulture | DropdownEditor | DropdownEditorCulture | EmailAddressEditor | EmailAddressEditorCulture | EyeDropperColorPickerEditor | EyeDropperColorPickerEditorCulture | FileUpload | FileUploadCulture | ImageCropperEditor | ImageCropperEditorCulture | LabelEditor | LabelEditorCulture | MarkdownEditor | MarkdownEditorCulture | MediaPickerEditor | MediaPickerEditorCulture | MemberGroupPickerEditor | MemberGroupPickerEditorCulture | MemberPickerEditor | MemberPickerEditorCulture | MultinodeTreepickerEditor | MultinodeTreepickerEditorCulture | MultiUrlPickerEditor | MultiUrlPickerEditorCulture | NumericEditor | NumericEditorCulture | RadioboxEditor | RadioboxEditorCulture | RepeatableTextstringsEditor | RepeatableTextstringsEditorCulture | RichtextEditor | RichtextEditorCulture | SiteWithCulture | SliderEditor | SliderEditorCulture | TagsEditor | TagsEditorCulture | TextareaEditor | TextareaEditorCulture | TextboxEditor | TextboxEditorCulture | ToggleEditor | ToggleEditorCulture | UmbBlockGridDemoHeadlineBlock | UmbBlockGridDemoImageBlock | UmbBlockGridDemoRichTextBlock | UserPickerEditor | UserPickerEditorCulture | BlockGridEditor1 | Image | File | UmbracoMediaVideo | UmbracoMediaAudio | UmbracoMediaArticle | UmbracoMediaVectorGraphics | CustomMediaType | Member | TestMember
+union TypedBlockListContentProperties =
+  | EmptyPropertyType
+  | BlockGridEditor
+  | BlockListEditor
+  | BlockListEditorCulture
+  | CheckboxListEditor
+  | CheckboxListEditorCulture
+  | ColorPickerEditor
+  | ColorPickerEditorCulture
+  | ContentPickerEditor
+  | ContentPickerEditorCulture
+  | DatePickerEditor
+  | DatePickerEditorCulture
+  | DecimalEditor
+  | DecimalEditorCulture
+  | Default
+  | DefaultCulture
+  | DropdownEditor
+  | DropdownEditorCulture
+  | EmailAddressEditor
+  | EmailAddressEditorCulture
+  | EyeDropperColorPickerEditor
+  | EyeDropperColorPickerEditorCulture
+  | FileUpload
+  | FileUploadCulture
+  | ImageCropperEditor
+  | ImageCropperEditorCulture
+  | LabelEditor
+  | LabelEditorCulture
+  | MarkdownEditor
+  | MarkdownEditorCulture
+  | MediaPickerEditor
+  | MediaPickerEditorCulture
+  | MemberGroupPickerEditor
+  | MemberGroupPickerEditorCulture
+  | MemberPickerEditor
+  | MemberPickerEditorCulture
+  | MultinodeTreepickerEditor
+  | MultinodeTreepickerEditorCulture
+  | MultiUrlPickerEditor
+  | MultiUrlPickerEditorCulture
+  | NumericEditor
+  | NumericEditorCulture
+  | RadioboxEditor
+  | RadioboxEditorCulture
+  | RepeatableTextstringsEditor
+  | RepeatableTextstringsEditorCulture
+  | RichtextEditor
+  | RichtextEditorCulture
+  | SiteWithCulture
+  | SliderEditor
+  | SliderEditorCulture
+  | TagsEditor
+  | TagsEditorCulture
+  | TextareaEditor
+  | TextareaEditorCulture
+  | TextboxEditor
+  | TextboxEditorCulture
+  | ToggleEditor
+  | ToggleEditorCulture
+  | UmbBlockGridDemoHeadlineBlock
+  | UmbBlockGridDemoImageBlock
+  | UmbBlockGridDemoRichTextBlock
+  | UserPickerEditor
+  | UserPickerEditorCulture
+  | BlockGridEditor1
+  | Image
+  | File
+  | UmbracoMediaVideo
+  | UmbracoMediaAudio
+  | UmbracoMediaArticle
+  | UmbracoMediaVectorGraphics
+  | CustomMediaType
+  | Member
+  | TestMember
 
 "Used to get typed properties on a block list property for the settings property"
-union TypedBlockListSettingsProperties = EmptyPropertyType | BlockGridEditor | BlockListEditor | BlockListEditorCulture | CheckboxListEditor | CheckboxListEditorCulture | ColorPickerEditor | ColorPickerEditorCulture | ContentPickerEditor | ContentPickerEditorCulture | DatePickerEditor | DatePickerEditorCulture | DecimalEditor | DecimalEditorCulture | Default | DefaultCulture | DropdownEditor | DropdownEditorCulture | EmailAddressEditor | EmailAddressEditorCulture | EyeDropperColorPickerEditor | EyeDropperColorPickerEditorCulture | FileUpload | FileUploadCulture | ImageCropperEditor | ImageCropperEditorCulture | LabelEditor | LabelEditorCulture | MarkdownEditor | MarkdownEditorCulture | MediaPickerEditor | MediaPickerEditorCulture | MemberGroupPickerEditor | MemberGroupPickerEditorCulture | MemberPickerEditor | MemberPickerEditorCulture | MultinodeTreepickerEditor | MultinodeTreepickerEditorCulture | MultiUrlPickerEditor | MultiUrlPickerEditorCulture | NumericEditor | NumericEditorCulture | RadioboxEditor | RadioboxEditorCulture | RepeatableTextstringsEditor | RepeatableTextstringsEditorCulture | RichtextEditor | RichtextEditorCulture | SiteWithCulture | SliderEditor | SliderEditorCulture | TagsEditor | TagsEditorCulture | TextareaEditor | TextareaEditorCulture | TextboxEditor | TextboxEditorCulture | ToggleEditor | ToggleEditorCulture | UmbBlockGridDemoHeadlineBlock | UmbBlockGridDemoImageBlock | UmbBlockGridDemoRichTextBlock | UserPickerEditor | UserPickerEditorCulture | BlockGridEditor1 | Image | File | UmbracoMediaVideo | UmbracoMediaAudio | UmbracoMediaArticle | UmbracoMediaVectorGraphics | CustomMediaType | Member | TestMember
+union TypedBlockListSettingsProperties =
+  | EmptyPropertyType
+  | BlockGridEditor
+  | BlockListEditor
+  | BlockListEditorCulture
+  | CheckboxListEditor
+  | CheckboxListEditorCulture
+  | ColorPickerEditor
+  | ColorPickerEditorCulture
+  | ContentPickerEditor
+  | ContentPickerEditorCulture
+  | DatePickerEditor
+  | DatePickerEditorCulture
+  | DecimalEditor
+  | DecimalEditorCulture
+  | Default
+  | DefaultCulture
+  | DropdownEditor
+  | DropdownEditorCulture
+  | EmailAddressEditor
+  | EmailAddressEditorCulture
+  | EyeDropperColorPickerEditor
+  | EyeDropperColorPickerEditorCulture
+  | FileUpload
+  | FileUploadCulture
+  | ImageCropperEditor
+  | ImageCropperEditorCulture
+  | LabelEditor
+  | LabelEditorCulture
+  | MarkdownEditor
+  | MarkdownEditorCulture
+  | MediaPickerEditor
+  | MediaPickerEditorCulture
+  | MemberGroupPickerEditor
+  | MemberGroupPickerEditorCulture
+  | MemberPickerEditor
+  | MemberPickerEditorCulture
+  | MultinodeTreepickerEditor
+  | MultinodeTreepickerEditorCulture
+  | MultiUrlPickerEditor
+  | MultiUrlPickerEditorCulture
+  | NumericEditor
+  | NumericEditorCulture
+  | RadioboxEditor
+  | RadioboxEditorCulture
+  | RepeatableTextstringsEditor
+  | RepeatableTextstringsEditorCulture
+  | RichtextEditor
+  | RichtextEditorCulture
+  | SiteWithCulture
+  | SliderEditor
+  | SliderEditorCulture
+  | TagsEditor
+  | TagsEditorCulture
+  | TextareaEditor
+  | TextareaEditorCulture
+  | TextboxEditor
+  | TextboxEditorCulture
+  | ToggleEditor
+  | ToggleEditorCulture
+  | UmbBlockGridDemoHeadlineBlock
+  | UmbBlockGridDemoImageBlock
+  | UmbBlockGridDemoRichTextBlock
+  | UserPickerEditor
+  | UserPickerEditorCulture
+  | BlockGridEditor1
+  | Image
+  | File
+  | UmbracoMediaVideo
+  | UmbracoMediaAudio
+  | UmbracoMediaArticle
+  | UmbracoMediaVectorGraphics
+  | CustomMediaType
+  | Member
+  | TestMember
 
 "Used to get typed properties on a nested content property"
-union TypedNestedContentProperties = EmptyPropertyType | BlockGridEditor | BlockListEditor | BlockListEditorCulture | CheckboxListEditor | CheckboxListEditorCulture | ColorPickerEditor | ColorPickerEditorCulture | ContentPickerEditor | ContentPickerEditorCulture | DatePickerEditor | DatePickerEditorCulture | DecimalEditor | DecimalEditorCulture | Default | DefaultCulture | DropdownEditor | DropdownEditorCulture | EmailAddressEditor | EmailAddressEditorCulture | EyeDropperColorPickerEditor | EyeDropperColorPickerEditorCulture | FileUpload | FileUploadCulture | ImageCropperEditor | ImageCropperEditorCulture | LabelEditor | LabelEditorCulture | MarkdownEditor | MarkdownEditorCulture | MediaPickerEditor | MediaPickerEditorCulture | MemberGroupPickerEditor | MemberGroupPickerEditorCulture | MemberPickerEditor | MemberPickerEditorCulture | MultinodeTreepickerEditor | MultinodeTreepickerEditorCulture | MultiUrlPickerEditor | MultiUrlPickerEditorCulture | NumericEditor | NumericEditorCulture | RadioboxEditor | RadioboxEditorCulture | RepeatableTextstringsEditor | RepeatableTextstringsEditorCulture | RichtextEditor | RichtextEditorCulture | SiteWithCulture | SliderEditor | SliderEditorCulture | TagsEditor | TagsEditorCulture | TextareaEditor | TextareaEditorCulture | TextboxEditor | TextboxEditorCulture | ToggleEditor | ToggleEditorCulture | UmbBlockGridDemoHeadlineBlock | UmbBlockGridDemoImageBlock | UmbBlockGridDemoRichTextBlock | UserPickerEditor | UserPickerEditorCulture | BlockGridEditor1 | Image | File | UmbracoMediaVideo | UmbracoMediaAudio | UmbracoMediaArticle | UmbracoMediaVectorGraphics | CustomMediaType | Member | TestMember
+union TypedNestedContentProperties =
+  | EmptyPropertyType
+  | BlockGridEditor
+  | BlockListEditor
+  | BlockListEditorCulture
+  | CheckboxListEditor
+  | CheckboxListEditorCulture
+  | ColorPickerEditor
+  | ColorPickerEditorCulture
+  | ContentPickerEditor
+  | ContentPickerEditorCulture
+  | DatePickerEditor
+  | DatePickerEditorCulture
+  | DecimalEditor
+  | DecimalEditorCulture
+  | Default
+  | DefaultCulture
+  | DropdownEditor
+  | DropdownEditorCulture
+  | EmailAddressEditor
+  | EmailAddressEditorCulture
+  | EyeDropperColorPickerEditor
+  | EyeDropperColorPickerEditorCulture
+  | FileUpload
+  | FileUploadCulture
+  | ImageCropperEditor
+  | ImageCropperEditorCulture
+  | LabelEditor
+  | LabelEditorCulture
+  | MarkdownEditor
+  | MarkdownEditorCulture
+  | MediaPickerEditor
+  | MediaPickerEditorCulture
+  | MemberGroupPickerEditor
+  | MemberGroupPickerEditorCulture
+  | MemberPickerEditor
+  | MemberPickerEditorCulture
+  | MultinodeTreepickerEditor
+  | MultinodeTreepickerEditorCulture
+  | MultiUrlPickerEditor
+  | MultiUrlPickerEditorCulture
+  | NumericEditor
+  | NumericEditorCulture
+  | RadioboxEditor
+  | RadioboxEditorCulture
+  | RepeatableTextstringsEditor
+  | RepeatableTextstringsEditorCulture
+  | RichtextEditor
+  | RichtextEditorCulture
+  | SiteWithCulture
+  | SliderEditor
+  | SliderEditorCulture
+  | TagsEditor
+  | TagsEditorCulture
+  | TextareaEditor
+  | TextareaEditorCulture
+  | TextboxEditor
+  | TextboxEditorCulture
+  | ToggleEditor
+  | ToggleEditorCulture
+  | UmbBlockGridDemoHeadlineBlock
+  | UmbBlockGridDemoImageBlock
+  | UmbBlockGridDemoRichTextBlock
+  | UserPickerEditor
+  | UserPickerEditorCulture
+  | BlockGridEditor1
+  | Image
+  | File
+  | UmbracoMediaVideo
+  | UmbracoMediaAudio
+  | UmbracoMediaArticle
+  | UmbracoMediaVectorGraphics
+  | CustomMediaType
+  | Member
+  | TestMember
 
 "Used to get typed properties on a model - For nested properties use TypedBlockListContentProperties, TypedBlockListSettingsProperties"
-union TypedProperties = EmptyPropertyType | BlockGridEditor | BlockListEditor | BlockListEditorCulture | CheckboxListEditor | CheckboxListEditorCulture | ColorPickerEditor | ColorPickerEditorCulture | ContentPickerEditor | ContentPickerEditorCulture | DatePickerEditor | DatePickerEditorCulture | DecimalEditor | DecimalEditorCulture | Default | DefaultCulture | DropdownEditor | DropdownEditorCulture | EmailAddressEditor | EmailAddressEditorCulture | EyeDropperColorPickerEditor | EyeDropperColorPickerEditorCulture | FileUpload | FileUploadCulture | ImageCropperEditor | ImageCropperEditorCulture | LabelEditor | LabelEditorCulture | MarkdownEditor | MarkdownEditorCulture | MediaPickerEditor | MediaPickerEditorCulture | MemberGroupPickerEditor | MemberGroupPickerEditorCulture | MemberPickerEditor | MemberPickerEditorCulture | MultinodeTreepickerEditor | MultinodeTreepickerEditorCulture | MultiUrlPickerEditor | MultiUrlPickerEditorCulture | NumericEditor | NumericEditorCulture | RadioboxEditor | RadioboxEditorCulture | RepeatableTextstringsEditor | RepeatableTextstringsEditorCulture | RichtextEditor | RichtextEditorCulture | SiteWithCulture | SliderEditor | SliderEditorCulture | TagsEditor | TagsEditorCulture | TextareaEditor | TextareaEditorCulture | TextboxEditor | TextboxEditorCulture | ToggleEditor | ToggleEditorCulture | UmbBlockGridDemoHeadlineBlock | UmbBlockGridDemoImageBlock | UmbBlockGridDemoRichTextBlock | UserPickerEditor | UserPickerEditorCulture | BlockGridEditor1 | Image | File | UmbracoMediaVideo | UmbracoMediaAudio | UmbracoMediaArticle | UmbracoMediaVectorGraphics | CustomMediaType | Member | TestMember
+union TypedProperties =
+  | EmptyPropertyType
+  | BlockGridEditor
+  | BlockListEditor
+  | BlockListEditorCulture
+  | CheckboxListEditor
+  | CheckboxListEditorCulture
+  | ColorPickerEditor
+  | ColorPickerEditorCulture
+  | ContentPickerEditor
+  | ContentPickerEditorCulture
+  | DatePickerEditor
+  | DatePickerEditorCulture
+  | DecimalEditor
+  | DecimalEditorCulture
+  | Default
+  | DefaultCulture
+  | DropdownEditor
+  | DropdownEditorCulture
+  | EmailAddressEditor
+  | EmailAddressEditorCulture
+  | EyeDropperColorPickerEditor
+  | EyeDropperColorPickerEditorCulture
+  | FileUpload
+  | FileUploadCulture
+  | ImageCropperEditor
+  | ImageCropperEditorCulture
+  | LabelEditor
+  | LabelEditorCulture
+  | MarkdownEditor
+  | MarkdownEditorCulture
+  | MediaPickerEditor
+  | MediaPickerEditorCulture
+  | MemberGroupPickerEditor
+  | MemberGroupPickerEditorCulture
+  | MemberPickerEditor
+  | MemberPickerEditorCulture
+  | MultinodeTreepickerEditor
+  | MultinodeTreepickerEditorCulture
+  | MultiUrlPickerEditor
+  | MultiUrlPickerEditorCulture
+  | NumericEditor
+  | NumericEditorCulture
+  | RadioboxEditor
+  | RadioboxEditorCulture
+  | RepeatableTextstringsEditor
+  | RepeatableTextstringsEditorCulture
+  | RichtextEditor
+  | RichtextEditorCulture
+  | SiteWithCulture
+  | SliderEditor
+  | SliderEditorCulture
+  | TagsEditor
+  | TagsEditorCulture
+  | TextareaEditor
+  | TextareaEditorCulture
+  | TextboxEditor
+  | TextboxEditorCulture
+  | ToggleEditor
+  | ToggleEditorCulture
+  | UmbBlockGridDemoHeadlineBlock
+  | UmbBlockGridDemoImageBlock
+  | UmbBlockGridDemoRichTextBlock
+  | UserPickerEditor
+  | UserPickerEditorCulture
+  | BlockGridEditor1
+  | Image
+  | File
+  | UmbracoMediaVideo
+  | UmbracoMediaAudio
+  | UmbracoMediaArticle
+  | UmbracoMediaVectorGraphics
+  | CustomMediaType
+  | Member
+  | TestMember
 
 "Represents the context of a query."
 input QueryContextInput {
@@ -1381,7 +2001,7 @@ input QueryContextInput {
   fallbacks: [PropertyFallback!]
   "The segment to use on a property value."
   segment: String
-  "The base URL of the request. Example: https:\/\/my-website.com. Used to return the correct URLs on content items"
+  "The base URL of the request. Example: https://my-website.com. Used to return the correct URLs on content items"
   baseUrl: String
 }
 
@@ -1428,18 +2048,17 @@ enum UrlMode {
   AUTO
 }
 
-"The authorize directive."
-directive @authorize("The name of the authorization policy that determines access to the annotated resource." policy: String "Roles that are allowed to access the annotated resource." roles: [String!] "Defines when when the authorize directive shall be applied.By default the authorize directives are applied during the validation phase." apply: ApplyPolicy! = BEFORE_RESOLVER) repeatable on OBJECT | FIELD_DEFINITION
+"The `Any` scalar type represents any valid GraphQL value."
+scalar Any @specifiedBy(url: "https://scalars.graphql.org/chillicream/any.html")
 
-"The `@specifiedBy` directive is used within the type system definition language to provide a URL for specifying the behavior of custom scalar definitions."
-directive @specifiedBy("The specifiedBy URL points to a human-readable specification. This field will only read a result for scalar types." url: String!) on SCALAR
+"The `DateTime` scalar type represents a date and time with time zone offset information."
+scalar DateTime
+  @specifiedBy(url: "https://scalars.graphql.org/chillicream/date-time.html")
 
-scalar Any
-
-"The `DateTime` scalar represents an ISO-8601 compliant date time type."
-scalar DateTime @specifiedBy(url: "https:\/\/www.graphql-scalars.com\/date-time")
-
-"The `Decimal` scalar type represents a decimal floating-point number."
+"The `Decimal` scalar type represents a decimal floating-point number with high precision."
 scalar Decimal
+  @specifiedBy(url: "https://scalars.graphql.org/chillicream/decimal.html")
 
-scalar UUID @specifiedBy(url: "https:\/\/tools.ietf.org\/html\/rfc4122")
+"The `UUID` scalar type represents a Universally Unique Identifier (UUID) as defined by RFC 9562."
+scalar UUID
+  @specifiedBy(url: "https://scalars.graphql.org/chillicream/uuid.html")

--- a/src/Nikcio.UHeadless.IntegrationTests/UHeadlessSetupComposer.cs
+++ b/src/Nikcio.UHeadless.IntegrationTests/UHeadlessSetupComposer.cs
@@ -1,3 +1,6 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Nikcio.UHeadless.IntegrationTests.TestProject;
 using Umbraco.Cms.Core.Composing;
 
 namespace Nikcio.UHeadless.IntegrationTests;
@@ -19,6 +22,13 @@ public class UHeadlessSetupComposer : IComposer
 
         ArgumentNullException.ThrowIfNull(headlessSetup);
 
-        builder.AddUHeadless(headlessSetup.GetSetup());
+        var setup = headlessSetup.GetSetup();
+        builder.AddUHeadless(options =>
+        {
+            setup(options);
+            options.RequestExecutorBuilder
+                .AddApplicationService<ILogger<GraphQLErrorFilter>>()
+                .AddErrorFilter<GraphQLErrorFilter>();
+        });
     }
 }

--- a/src/Nikcio.UHeadless/TypeModules/UmbracoTypeModule.cs
+++ b/src/Nikcio.UHeadless/TypeModules/UmbracoTypeModule.cs
@@ -1,7 +1,7 @@
 using HotChocolate.Execution.Configuration;
 using HotChocolate.Resolvers;
 using HotChocolate.Types.Descriptors;
-using HotChocolate.Types.Descriptors.Definitions;
+using HotChocolate.Types.Descriptors.Configurations;
 using Microsoft.Extensions.Logging;
 using Nikcio.UHeadless.Common.Properties;
 using Nikcio.UHeadless.Properties;
@@ -155,7 +155,7 @@ internal class UmbracoTypeModule : ITypeModule
 
         foreach (IContentTypeComposition? contentType in allContentTypes)
         {
-            InterfaceTypeDefinition? interfaceTypeDefinition = CreateInterfaceTypeDefinition(contentType);
+            InterfaceTypeConfiguration? interfaceTypeDefinition = CreateInterfaceTypeConfiguration(contentType);
 
             if (interfaceTypeDefinition == null)
             {
@@ -170,7 +170,7 @@ internal class UmbracoTypeModule : ITypeModule
 
         foreach (IContentTypeComposition contentType in interfacedContentTypes)
         {
-            ObjectTypeDefinition objectTypeDefinition = CreateObjectTypeDefinition(contentType, interfaceTypeNames);
+            ObjectTypeConfiguration objectTypeDefinition = CreateObjectTypeConfiguration(contentType, interfaceTypeNames);
 
             if (objectTypeDefinition.Fields.Count == 0)
             {
@@ -234,14 +234,14 @@ internal class UmbracoTypeModule : ITypeModule
     /// <param name="objectTypes"></param>
     private static void AddEmptyPropertyType(List<ObjectType> objectTypes)
     {
-        var emptyNamedProperty = new ObjectTypeDefinition($"EmptyPropertyType", "Represents a content type that doesn't have any properties and therefore needs a placeholder");
-        emptyNamedProperty.Fields.Add(new ObjectFieldDefinition("Empty_Field", "Placeholder field. Will never hold a value.", type: TypeReference.Parse("String!"), pureResolver: _ => string.Empty));
+        var emptyNamedProperty = new ObjectTypeConfiguration($"EmptyPropertyType", "Represents a content type that doesn't have any properties and therefore needs a placeholder");
+        emptyNamedProperty.Fields.Add(new ObjectFieldConfiguration("Empty_Field", "Placeholder field. Will never hold a value.", type: TypeReference.Parse("String!"), pureResolver: _ => string.Empty));
         objectTypes.Add(ObjectType.CreateUnsafe(emptyNamedProperty));
     }
 
-    private InterfaceTypeDefinition? CreateInterfaceTypeDefinition(IContentTypeComposition contentType)
+    private InterfaceTypeConfiguration? CreateInterfaceTypeConfiguration(IContentTypeComposition contentType)
     {
-        var interfaceTypeDefinition = new InterfaceTypeDefinition(GetInterfaceTypeName(contentType.Alias), contentType.Description);
+        var interfaceTypeDefinition = new InterfaceTypeConfiguration(GetInterfaceTypeName(contentType.Alias), contentType.Description);
 
         foreach (IPropertyType property in contentType.CompositionPropertyTypes)
         {
@@ -254,7 +254,7 @@ internal class UmbracoTypeModule : ITypeModule
                 continue;
             }
 
-            interfaceTypeDefinition.Fields.Add(new InterfaceFieldDefinition(property.Alias, property.Description, TypeReference.Parse(propertyType.Name)));
+            interfaceTypeDefinition.Fields.Add(new InterfaceFieldConfiguration(property.Alias, property.Description, TypeReference.Parse(propertyType.Name)));
         }
 
         if (interfaceTypeDefinition.Fields.Count == 0)
@@ -265,9 +265,9 @@ internal class UmbracoTypeModule : ITypeModule
         return interfaceTypeDefinition;
     }
 
-    private ObjectTypeDefinition CreateObjectTypeDefinition(IContentTypeComposition contentType, HashSet<string> interfaceTypeNames)
+    private ObjectTypeConfiguration CreateObjectTypeConfiguration(IContentTypeComposition contentType, HashSet<string> interfaceTypeNames)
     {
-        var typeDefinition = new ObjectTypeDefinition(GetObjectTypeName(contentType.Alias), contentType.Description);
+        var typeDefinition = new ObjectTypeConfiguration(GetObjectTypeName(contentType.Alias), contentType.Description);
 
         foreach (IPropertyType property in contentType.CompositionPropertyTypes)
         {
@@ -280,7 +280,7 @@ internal class UmbracoTypeModule : ITypeModule
                 continue;
             }
 
-            typeDefinition.Fields.Add(new ObjectFieldDefinition(property.Alias, property.Description, TypeReference.Parse(propertyType.Name), resolver: ResolvePropertyValueAsync));
+            typeDefinition.Fields.Add(new ObjectFieldConfiguration(property.Alias, property.Description, TypeReference.Parse(propertyType.Name), resolver: ResolvePropertyValueAsync));
         }
 
         foreach (string composite in contentType.CompositionAliases())

--- a/src/Nikcio.UHeadless/UHeadlessExtensions.cs
+++ b/src/Nikcio.UHeadless/UHeadlessExtensions.cs
@@ -1,9 +1,11 @@
 using System.ComponentModel.DataAnnotations;
+using System.Text.Json;
 using HotChocolate.AspNetCore.Extensions;
 using HotChocolate.Execution.Configuration;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json.Linq;
 using Nikcio.UHeadless.Common.Properties;
 using Nikcio.UHeadless.ContentItems;
 using Nikcio.UHeadless.Defaults;
@@ -37,7 +39,9 @@ public static class UHeadlessExtensions
             {
                 options.EnforceCostLimits = false;
                 options.ApplyCostDefaults = false;
-            });
+            })
+            .AddJsonTypeConverter()
+            .AddTypeConverter<JToken, JsonElement>(token => JsonDocument.Parse(token.ToString(Newtonsoft.Json.Formatting.None)).RootElement);
 
         var options = new UHeadlessOptions()
         {
@@ -85,7 +89,6 @@ public static class UHeadlessExtensions
         builder.AddNotificationAsyncHandler<MemberTypeChangedNotification, MemberTypeChangedHandler>();
 
         requestExecutorBuilder
-            .InitializeOnStartup()
             .AddAuthorization()
             .AddInterfaceType<PropertyValue>()
             .AddTypeModule<UmbracoTypeModule>();


### PR DESCRIPTION
## Breaking Change

This PR upgrades HotChocolate from 15.1.17 to 16.6.1 and the strawberryshake.tools dotnet tool from 15.1.13 to 16.6.1. The upgrade follows the [official migration guide](https://chillicream.com/docs/hotchocolate/migrating/migrate-from-15-to-16).

### Dependency upgrades
- HotChocolate.AspNetCore 15.1.17 → 16.6.1
- HotChocolate.AspNetCore.Authorization 15.1.17 → 16.6.1
- HotChocolate.PersistedOperations.InMemory 15.1.17 → 16.6.1
- strawberryshake.tools 15.1.13 → 16.6.1

### Code changes
- **Removed `InitializeOnStartup()`** — eager initialization is now the default in v16
- **Renamed `*TypeDefinition` → `*TypeConfiguration`** and namespace `HotChocolate.Types.Descriptors.Definitions` → `.Configurations` in `UmbracoTypeModule.cs`
- **Added `AddJsonTypeConverter()`** and a `JToken → JsonElement` type converter so the `Any` scalar (now backed by `System.Text.Json.JsonElement`) can serialize CLR objects returned by Umbraco property value converters
- **Migrated `AddErrorFilter`** from `IServiceCollection` to `IRequestExecutorBuilder` with `AddApplicationService<T>()` cross-registration, as required by the v16 schema/application service provider separation
- **Added `HotChocolate.Execution` using** for `IErrorFilter` (moved namespace in v16)
- **Switched `WithOptions` to delegate pattern** in starter-example (v16 API change)

### GraphQL response / schema behavioral changes (snapshots updated)
- Error responses no longer include `locations` for resolver-thrown exceptions
- `Any` scalar now serializes via `System.Text.Json`, respecting `[JsonPropertyName]` attributes (e.g. Umbraco `PickedColor.Color` → `"value"` instead of `"color"`)
- `DateTime` scalar strips zero fractional seconds (`2023-04-25T12:00:00.000Z` → `2023-04-25T12:00:00Z`)
- `UUID` scalar error message format changed
- Schema SDL includes default argument values and restructured type ordering

### Testing
All 245 tests (835 unit + 245 integration) pass.