### PR TITLE
docs: add v12.0.0 documentation and update README compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The Nikcio.UHeadless package is compatible with the following Umbraco versions:
 | Umbraco 15           | v7.x.x & v8.x.x       |
 | Umbraco 16           | v9.x.x                |
 | Umbraco 17           | v10.x.x               |
-| Umbraco 18           | v11.x.x               |
+| Umbraco 18           | v11.x.x & v12.x.x     |
 
 For more information, please refer to the [Versioning](#versioning) section.
 
@@ -141,7 +141,7 @@ vX.Y.Z
 | Umbraco 15           | v7.x.x & v8.x.x       | No development                        |
 | Umbraco 16           | v9.x.x                | No development                        |
 | Umbraco 17           | v10.x.x               | No development                        |
-| Umbraco 18           | v11.x.x               | Active branch                         |
+| Umbraco 18           | v11.x.x & v12.x.x     | Active branch                         |
 
 ## Contributing
 

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -69,7 +69,7 @@ export default defineConfig({
 					label: "Welcome",
 					items: [
 						{ label: "Overview", link: "/overview/" },
-						{ label: "Version 11", link: "/v11/start/" },
+						{ label: "Version 12", link: "/v12/start/" },
 					],
 				},
 				{
@@ -77,25 +77,25 @@ export default defineConfig({
 					items: [
 						{
 							label: "Getting started",
-							link: "v11/fundamentals/getting-started/",
+							link: "v12/fundamentals/getting-started/",
 						},
-						{ label: "Security", link: "v11/fundamentals/security/" },
+						{ label: "Security", link: "v12/fundamentals/security/" },
 						{
 							label: "Querying",
 							collapsed: true,
 							items: [
 								{
 									label: "Content",
-									link: "v11/fundamentals/querying/content/",
+									link: "v12/fundamentals/querying/content/",
 								},
-								{ label: "Media", link: "v11/fundamentals/querying/media/" },
+								{ label: "Media", link: "v12/fundamentals/querying/media/" },
 								{
 									label: "Members",
-									link: "v11/fundamentals/querying/members/",
+									link: "v12/fundamentals/querying/members/",
 								},
 								{
 									label: "Properties",
-									link: "v11/fundamentals/querying/properties/",
+									link: "v12/fundamentals/querying/properties/",
 								},
 							],
 						},
@@ -104,32 +104,32 @@ export default defineConfig({
 				{
 					label: "Extending",
 					items: [
-						{ label: "Content", link: "v11/extending/content/" },
-						{ label: "Media", link: "v11/extending/media/" },
-						{ label: "Member", link: "v11/extending/member/" },
+						{ label: "Content", link: "v12/extending/content/" },
+						{ label: "Media", link: "v12/extending/media/" },
+						{ label: "Member", link: "v12/extending/member/" },
 						{
 							label: "Properties",
 							collapsed: true,
 							items: [
 								{
 									label: "Overview",
-									link: "v11/extending/properties/overview/",
+									link: "v12/extending/properties/overview/",
 								},
 								{
 									label: "Rich text",
-									link: "v11/extending/properties/rich-text/",
+									link: "v12/extending/properties/rich-text/",
 								},
 								{
 									label: "Media picker",
-									link: "v11/extending/properties/media-picker/",
+									link: "v12/extending/properties/media-picker/",
 								},
 								{
 									label: "Block list",
-									link: "v11/extending/properties/block-list/",
+									link: "v12/extending/properties/block-list/",
 								},
 								{
 									label: "Custom editor",
-									link: "v11/extending/properties/custom-editor/",
+									link: "v12/extending/properties/custom-editor/",
 								},
 							],
 						},
@@ -138,21 +138,108 @@ export default defineConfig({
 				{
 					label: "Reference",
 					items: [
-						{ label: "Options", link: "v11/reference/options/" },
+						{ label: "Options", link: "v12/reference/options/" },
 						{
 							label: "Endpoint options",
-							link: "v11/reference/endpoint-options/",
+							link: "v12/reference/endpoint-options/",
 						},
-						{ label: "Content", link: "v11/reference/content/" },
-						{ label: "Media", link: "v11/reference/media/" },
-						{ label: "Member", link: "v11/reference/member/" },
-						{ label: "Member", link: "v11/reference/properties/" },
+						{ label: "Content", link: "v12/reference/content/" },
+						{ label: "Media", link: "v12/reference/media/" },
+						{ label: "Member", link: "v12/reference/member/" },
+						{ label: "Member", link: "v12/reference/properties/" },
 					],
 				},
 				{
 					label: "Older versions",
 					collapsed: true,
 					items: [
+						{
+							label: "Version 11",
+							collapsed: true,
+							items: [
+								{ label: "Overview", link: "/v11/start/" },
+								{
+									label: "Fundamentals",
+									items: [
+										{
+											label: "Getting started",
+											link: "v11/fundamentals/getting-started/",
+										},
+										{ label: "Security", link: "v11/fundamentals/security/" },
+										{
+											label: "Querying",
+											collapsed: true,
+											items: [
+												{
+													label: "Content",
+													link: "v11/fundamentals/querying/content/",
+												},
+												{
+													label: "Media",
+													link: "v11/fundamentals/querying/media/",
+												},
+												{
+													label: "Members",
+													link: "v11/fundamentals/querying/members/",
+												},
+												{
+													label: "Properties",
+													link: "v11/fundamentals/querying/properties/",
+												},
+											],
+										},
+									],
+								},
+								{
+									label: "Extending",
+									items: [
+										{ label: "Content", link: "v11/extending/content/" },
+										{ label: "Media", link: "v11/extending/media/" },
+										{ label: "Member", link: "v11/extending/member/" },
+										{
+											label: "Properties",
+											collapsed: true,
+											items: [
+												{
+													label: "Overview",
+													link: "v11/extending/properties/overview/",
+												},
+												{
+													label: "Rich text",
+													link: "v11/extending/properties/rich-text/",
+												},
+												{
+													label: "Media picker",
+													link: "v11/extending/properties/media-picker/",
+												},
+												{
+													label: "Block list",
+													link: "v11/extending/properties/block-list/",
+												},
+												{
+													label: "Custom editor",
+													link: "v11/extending/properties/custom-editor/",
+												},
+											],
+										},
+									],
+								},
+								{
+									label: "Reference",
+									items: [
+										{ label: "Options", link: "v11/reference/options/" },
+										{
+											label: "Endpoint options",
+											link: "v11/reference/endpoint-options/",
+										},
+										{ label: "Content", link: "v11/reference/content/" },
+										{ label: "Media", link: "v11/reference/media/" },
+										{ label: "Member", link: "v11/reference/member/" },
+										{ label: "Member", link: "v11/reference/properties/" },
+									],
+								},
+							],
+						},
 						{
 							label: "Version 10",
 							collapsed: true,

--- a/docs/src/content/docs/overview.md
+++ b/docs/src/content/docs/overview.md
@@ -16,6 +16,7 @@ Welcome to the documentation for Nikcio.UHeadless! Here you will find resources 
 - [Version 9.0.0+](../v9/start/): Documentation for version 9.0.0 and above.
 - [Version 10.0.0+](../v10/start/): Documentation for version 10.0.0 and above.
 - [Version 11.0.0+](../v11/start/): Documentation for version 11.0.0 and above.
+- [Version 12.0.0+](../v12/start/): Documentation for version 12.0.0 and above.
 
 Choose the appropriate version and explore the documentation tailored to your needs.
 

--- a/docs/src/content/docs/v12/extending/content.md
+++ b/docs/src/content/docs/v12/extending/content.md
@@ -1,0 +1,291 @@
+---
+title: Extending Content Data Structures in Nikcio.UHeadless
+description: Learn how to extend the content model in Nikcio.UHeadless.
+---
+
+Nikcio.UHeadless provides flexibility to extend and replace content data structures to accommodate your specific needs. This documentation outlines some examples of how you can extend the content data structures.
+
+## Example custom content model extending the existing content model:
+
+1. Create your content model by inheriting from `Nikcio.UHeadless.Defaults.ContentItems.ContentItem`:
+
+```csharp
+using HotChocolate;
+using HotChocolate.Resolvers;
+
+/// <summary>
+/// This example demonstrates how to create a custom content item with custom properties and methods.
+/// </summary>
+/// <remarks>
+/// The <see cref="IResolverContext"/> can be used to resolve services from the DI container like you normally would with dependency injection.
+/// It's important to contain any logic to the specific property or method within the property or method itself if possiable.
+/// As GraphQL will only call the properties or methods that are requestedm and may not call all of them.
+/// </remarks>
+[GraphQLName("CustomContentItemExampleContentItem")]
+public class ContentItem : Nikcio.UHeadless.Defaults.ContentItems.ContentItem
+{
+    public ContentItem(CreateCommand command) : base(command)
+    {
+    }
+
+    public string? CustomProperty => "Custom value";
+
+    public string? CustomMethod()
+    {
+        return "Custom method";
+    }
+
+    public string? CustomMethodWithParameter(string? parameter)
+    {
+        return $"Custom method with parameter: {parameter}";
+    }
+
+    public string? CustomMethodWithResolverContext(IResolverContext resolverContext)
+    {
+        ArgumentNullException.ThrowIfNull(resolverContext);
+
+        IHttpContextAccessor httpContextAccessor = resolverContext.Service<IHttpContextAccessor>();
+
+        return $"Custom method with resolver context so you can resolve the services needed: {httpContextAccessor.HttpContext?.Request.Path}";
+    }
+}
+```
+
+When making your model you can use properties and methods to expose data. When using methods you can add parameters to the method to make it more dynamic. You can also use the `IResolverContext` to resolve services from the DI container. Every parameter except the `IResolverContext` will be a part of the GraphQL schema and will be a paramter you pass to the query.
+
+2. Extend the query where you want the model to be present. In this example, we extend the `ContentByIdQuery` query:
+
+```csharp
+using HotChocolate;
+using HotChocolate.Resolvers;
+using HotChocolate.Types;
+using Nikcio.UHeadless;
+using Nikcio.UHeadless.ContentItems;
+using Nikcio.UHeadless.Defaults.ContentItems;
+using Umbraco.Cms.Core.Models.PublishedContent;
+
+[ExtendObjectType(typeof(HotChocolateQueryObject))]
+public class CustomContentItemExampleQuery : ContentByIdQuery<ContentItem>
+{
+    [GraphQLName("CustomContentItemExampleQuery")]
+    public override ContentItem? ContentById(
+        IResolverContext resolverContext,
+        [GraphQLDescription("The id to fetch.")] int id,
+        [GraphQLDescription("The context of the request.")] QueryContext? inContext = null)
+    {
+        return base.ContentById(resolverContext, id, inContext);
+    }
+
+    protected override ContentItem? CreateContentItem(IPublishedContent? publishedContent, IContentItemRepository<ContentItem> contentItemRepository, IResolverContext resolverContext)
+    {
+        ArgumentNullException.ThrowIfNull(contentItemRepository);
+
+        return contentItemRepository.GetContentItem(new Nikcio.UHeadless.Defaults.ContentItems.ContentItem.CreateCommand()
+        {
+            PublishedContent = publishedContent,
+            ResolverContext = resolverContext,
+            StatusCode = publishedContent == null ? StatusCodes.Status404NotFound : StatusCodes.Status200OK,
+            Redirect = null
+        });
+    }
+}
+
+```
+
+If you don't already have the `ContentByIdQuery` you don't need to override the `ContentById` method as you don't need to alter the `GraphQLName` which is the name of the query in the schema. This defaults to the query names you would normally use when using the query. (In this example `contentById`)
+
+3. Register the query in Nikcio.UHeadless:
+
+```csharp
+.AddUHeadless(options =>
+{
+    options.AddQuery<CustomContentItemExampleQuery>();
+})
+```
+
+4. Open `/graphql` and observe your new model for the `CustomContentItemExampleQuery` query.
+
+## Example extended the content model with public access settings:
+
+1. Create your access rule model:
+
+```csharp
+using HotChocolate;
+
+[GraphQLDescription("Represents an access rule for the restrict public access settings.")]
+public class AccessRuleModel
+{
+    public AccessRuleModel(string? ruleType, string? ruleValue)
+    {
+        RuleType = ruleType ?? string.Empty;
+        RuleValue = ruleValue ?? string.Empty;
+    }
+
+    [GraphQLDescription("Gets the type of protection to grant access to the content item.")]
+    public string RuleType { get; set; }
+
+    [GraphQLDescription("Gets the name of who has access to the content item.")]
+    public string RuleValue { get; set; }
+}
+
+```
+
+2. Create your Permissions model:
+
+```csharp
+using HotChocolate;
+
+[GraphQLDescription("Represents a restrict public access settings of a content item.")]
+public class PermissionsModel
+{
+    public PermissionsModel()
+    {
+        AccessRules = [];
+    }
+
+    [GraphQLDescription("Gets the url to the login page.")]
+    public string? UrlLogin { get; set; }
+
+    [GraphQLDescription("Gets the url to the error page.")]
+    public string? UrlNoAccess { get; set; }
+
+    [GraphQLDescription("Gets the access rules for the restrict public access settings.")]
+    public List<AccessRuleModel> AccessRules { get; set; }
+}
+```
+
+3. Create your content model:
+
+```csharp
+using HotChocolate;
+using HotChocolate.Resolvers;
+using Nikcio.UHeadless;
+using Nikcio.UHeadless.ContentItems;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Cms.Core.PublishedCache;
+using Umbraco.Cms.Core.Routing;
+using Umbraco.Cms.Core.Services;
+
+/// <summary>
+/// This example demonstrates how to create a custom content item that includes the public access settings from Umbraco.
+/// with this information you can block access to content based on the user using the site.
+/// </summary>
+/// <remarks>
+/// This example uses the default <see cref="Nikcio.UHeadless.Defaults.ContentItems.ContentItem"/> class from UHeadless
+/// but could also be implemented using the <see cref="Nikcio.UHeadless.ContentItems.ContentItemBase"/> class.
+/// </remarks>
+[GraphQLName("PublishAccessExampleContentItem")]
+public class ContentItem : Nikcio.UHeadless.Defaults.ContentItems.ContentItem
+{
+    public ContentItem(CreateCommand command) : base(command)
+    {
+    }
+
+    [GraphQLDescription("Gets the restrict public access settings of the content item.")]
+    public PermissionsModel? Permissions(IResolverContext resolverContext)
+    {
+        ArgumentNullException.ThrowIfNull(resolverContext);
+
+        ILogger<ContentItem> logger = resolverContext.Service<ILogger<ContentItem>>();
+        IContentService contentService = resolverContext.Service<IContentService>();
+        IPublicAccessService publicAccessService = resolverContext.Service<IPublicAccessService>();
+        IContentItemRepository<ContentItem> contentItemRepository = resolverContext.Service<IContentItemRepository<ContentItem>>();
+
+        if (PublishedContent == null)
+        {
+            logger.LogWarning("Content is null");
+            return null;
+        }
+
+        IContent? content = contentService.GetById(PublishedContent.Id);
+
+        if (content == null)
+        {
+            logger.LogWarning("Content from content service is null. Id: {ContentId}", PublishedContent.Id);
+            return null;
+        }
+
+        PublicAccessEntry? entry = publicAccessService.GetEntryForContent(content);
+
+        if (entry == null)
+        {
+            logger.LogWarning("Public access entry is null. ContentId: {ContentId}", PublishedContent.Id);
+            return null;
+        }
+
+        IPublishedContentCache? contentCache = contentItemRepository.GetCache();
+
+        if (contentCache == null)
+        {
+            throw new InvalidOperationException("The content cache is not available");
+        }
+
+        IPublishedContent? loginContent = contentCache.GetById(entry.LoginNodeId);
+        IPublishedContent? noAccessContent = contentCache.GetById(entry.NoAccessNodeId);
+
+        var permissions = new PermissionsModel
+        {
+            UrlLogin = loginContent?.Url(resolverContext.Service<IPublishedUrlProvider>(), resolverContext.Culture(), UrlMode.Absolute),
+            UrlNoAccess = noAccessContent?.Url(resolverContext.Service<IPublishedUrlProvider>(), resolverContext.Culture(), UrlMode.Absolute)
+        };
+
+        foreach (PublicAccessRule rule in entry.Rules)
+        {
+            permissions.AccessRules.Add(new AccessRuleModel(rule.RuleType, rule.RuleValue));
+        }
+
+        return permissions;
+    }
+}
+```
+
+4. Extend the query where you want the model to be present. In this example, we extend the `ContentByIdQuery` query:
+
+```csharp
+using HotChocolate;
+using HotChocolate.Resolvers;
+using HotChocolate.Types;
+using Nikcio.UHeadless;
+using Nikcio.UHeadless.ContentItems;
+using Nikcio.UHeadless.Defaults.ContentItems;
+using Umbraco.Cms.Core.Models.PublishedContent;
+
+[ExtendObjectType(typeof(HotChocolateQueryObject))]
+public class PublishAccessExampleQuery : ContentByIdQuery<ContentItem>
+{
+    [GraphQLName("publishAccessExampleQuery")]
+    public override ContentItem? ContentById(
+        IResolverContext resolverContext,
+        [GraphQLDescription("The id to fetch.")] int id,
+        [GraphQLDescription("The context of the request.")] QueryContext? inContext = null)
+    {
+        return base.ContentById(resolverContext, id, inContext);
+    }
+
+    protected override ContentItem? CreateContentItem(IPublishedContent? publishedContent, IContentItemRepository<ContentItem> contentItemRepository, IResolverContext resolverContext)
+    {
+        ArgumentNullException.ThrowIfNull(contentItemRepository);
+
+        return contentItemRepository.GetContentItem(new Nikcio.UHeadless.Defaults.ContentItems.ContentItem.CreateCommand()
+        {
+            PublishedContent = publishedContent,
+            ResolverContext = resolverContext,
+            StatusCode = publishedContent == null ? StatusCodes.Status404NotFound : StatusCodes.Status200OK,
+            Redirect = null
+        });
+    }
+}
+
+```
+
+3. Register the query in Nikcio.UHeadless:
+
+```csharp
+.AddUHeadless(options =>
+{
+    options.AddQuery<PublishAccessExampleQuery>();
+})
+```
+
+4. Open `/graphql` and observe your new model for the `publishAccessExampleQuery` query.

--- a/docs/src/content/docs/v12/extending/media.md
+++ b/docs/src/content/docs/v12/extending/media.md
@@ -1,0 +1,102 @@
+---
+title: Extending Media Data Structures in Nikcio.UHeadless
+description: Learn how to extend the media model in Nikcio.UHeadless.
+---
+
+Nikcio.UHeadless provides flexibility to extend and replace media data structures to accommodate your specific needs. This documentation outlines three examples of how you can extend the media data structures.
+
+## Example custom media model extending the existing media model:
+
+1. Create your own media model by inheriting from `Nikcio.UHeadless.Defaults.MediaItems.MediaItem`:
+
+```csharp
+using HotChocolate.Resolvers;
+using HotChocolate;
+
+/// <summary>
+/// This example demonstrates how to create a custom media item with custom properties and methods.
+/// </summary>
+/// <remarks>
+/// The <see cref="IResolverContext"/> can be used to resolve services from the DI container like you normally would with dependency injection.
+/// It's important to contain any logic to the specific property or method within the property or method itself if possiable.
+/// As GraphQL will only call the properties or methods that are requestedm and may not call all of them.
+/// </remarks>
+[GraphQLName("CustomMediaItemExampleMediaItem")]
+public class MediaItem : Nikcio.UHeadless.Defaults.MediaItems.MediaItem
+{
+    public MediaItem(CreateCommand command) : base(command)
+    {
+    }
+
+    public string? CustomProperty => "Custom value";
+
+    public string? CustomMethod()
+    {
+        return "Custom method";
+    }
+
+    public string? CustomMethodWithParameter(string? parameter)
+    {
+        return $"Custom method with parameter: {parameter}";
+    }
+
+    public string? CustomMethodWithResolverContext(IResolverContext resolverContext)
+    {
+        ArgumentNullException.ThrowIfNull(resolverContext);
+
+        IHttpContextAccessor httpContextAccessor = resolverContext.Service<IHttpContextAccessor>();
+
+        return $"Custom method with resolver context so you can resolve the services needed: {httpContextAccessor.HttpContext?.Request.Path}";
+    }
+}
+```
+
+When making your model you can use properties and methods to expose data. When using methods you can add parameters to the method to make it more dynamic. You can also use the `IResolverContext` to resolve services from the DI container. Every parameter except the `IResolverContext` will be a part of the GraphQL schema and will be a paramter you pass to the query.
+
+2. Extend the query where you want the model to be present. In this example, we extend the `MediaByIdQuery` query:
+
+```csharp
+using HotChocolate;
+using HotChocolate.Resolvers;
+using HotChocolate.Types;
+using Nikcio.UHeadless;
+using Nikcio.UHeadless.Defaults.MediaItems;
+using Nikcio.UHeadless.MediaItems;
+using Umbraco.Cms.Core.Models.PublishedContent;
+
+[ExtendObjectType(typeof(HotChocolateQueryObject))]
+public class CustomMediaItemExampleQuery : MediaByIdQuery<MediaItem>
+{
+    [GraphQLName("CustomMediaItemExampleQuery")]
+    public override MediaItem? MediaById(
+        IResolverContext resolverContext,
+        [GraphQLDescription("The id to fetch.")] int id)
+    {
+        return base.MediaById(resolverContext, id);
+    }
+
+    protected override MediaItem? CreateMediaItem(IPublishedContent? media, IMediaItemRepository<MediaItem> mediaItemRepository, IResolverContext resolverContext)
+    {
+        ArgumentNullException.ThrowIfNull(mediaItemRepository);
+
+        return mediaItemRepository.GetMediaItem(new Nikcio.UHeadless.Media.MediaItemBase.CreateCommand()
+        {
+            PublishedContent = media,
+            ResolverContext = resolverContext,
+        });
+    }
+}
+```
+
+If you don't already have the `MediaByIdQuery` you don't need to override the `MediaById` method as you don't need to alter the `GraphQLName` which is the name of the query in the schema. This defaults to the query names you would normally use when using the query. (In this example `MediaById`)
+
+3. Register the query in Nikcio.UHeadless:
+
+```csharp
+.AddUHeadless(options =>
+{
+    options.AddQuery<CustomMediaItemExampleQuery>();
+})
+```
+
+4. Open `/graphql` and observe your new model for the `CustomMediaItemExampleQuery` query.

--- a/docs/src/content/docs/v12/extending/member.md
+++ b/docs/src/content/docs/v12/extending/member.md
@@ -1,0 +1,103 @@
+---
+title: Extending Member Data Structures in Nikcio.UHeadless
+description: Learn how to extend the member model in Nikcio.UHeadless.
+---
+
+Nikcio.UHeadless provides flexibility to extend and replace member data structures to accommodate your specific needs. This documentation outlines three examples of how you can extend the member data structures.
+
+## Example custom member model extending the existing member model:
+
+1. Create your own member model by inheriting from `Nikcio.UHeadless.Defaults.Members.MemberItem`:
+
+```csharp
+using HotChocolate.Resolvers;
+using HotChocolate;
+
+/// <summary>
+/// This example demonstrates how to create a custom member item with custom properties and methods.
+/// </summary>
+/// <remarks>
+/// The <see cref="IResolverContext"/> can be used to resolve services from the DI container like you normally would with dependency injection.
+/// It's important to contain any logic to the specific property or method within the property or method itself if possiable.
+/// As GraphQL will only call the properties or methods that are requestedm and may not call all of them.
+/// </remarks>
+[GraphQLName("CustomMemberItemExampleMemberItem")]
+public class MemberItem : Nikcio.UHeadless.Defaults.Members.MemberItem
+{
+    public MemberItem(CreateCommand command) : base(command)
+    {
+    }
+
+    public string? CustomProperty => "Custom value";
+
+    public string? CustomMethod()
+    {
+        return "Custom method";
+    }
+
+    public string? CustomMethodWithParameter(string? parameter)
+    {
+        return $"Custom method with parameter: {parameter}";
+    }
+
+    public string? CustomMethodWithResolverContext(IResolverContext resolverContext)
+    {
+        ArgumentNullException.ThrowIfNull(resolverContext);
+
+        IHttpContextAccessor httpContextAccessor = resolverContext.Service<IHttpContextAccessor>();
+
+        return $"Custom method with resolver context so you can resolve the services needed: {httpContextAccessor.HttpContext?.Request.Path}";
+    }
+}
+```
+
+When making your model you can use properties and methods to expose data. When using methods you can add parameters to the method to make it more dynamic. You can also use the `IResolverContext` to resolve services from the DI container. Every parameter except the `IResolverContext` will be a part of the GraphQL schema and will be a paramter you pass to the query.
+
+2. Extend the query where you want the model to be present. In this example, we extend the `MemberByIdQuery` query:
+
+```csharp
+using HotChocolate;
+using HotChocolate.Resolvers;
+using HotChocolate.Types;
+using Nikcio.UHeadless;
+using Nikcio.UHeadless.Defaults.Members;
+using Nikcio.UHeadless.MemberItems;
+using Umbraco.Cms.Core.Models.PublishedContent;
+
+[ExtendObjectType(typeof(HotChocolateQueryObject))]
+public class CustomMemberItemExampleQuery : MemberByIdQuery<MemberItem>
+{
+    [GraphQLName("CustomMemberItemExampleQuery")]
+    public override MemberItem? MemberById(
+        IResolverContext resolverContext,
+        [GraphQLDescription("The id to fetch.")] int id)
+    {
+        return base.MemberById(resolverContext, id);
+    }
+
+    protected override MemberItem? CreateMemberItem(IPublishedContent? member, IMemberItemRepository<MemberItem> memberItemRepository, IResolverContext resolverContext)
+    {
+        ArgumentNullException.ThrowIfNull(memberItemRepository);
+
+        return memberItemRepository.GetMemberItem(new Nikcio.UHeadless.Members.MemberItemBase.CreateCommand()
+        {
+            PublishedContent = member,
+            ResolverContext = resolverContext,
+        });
+    }
+}
+
+```
+
+If you don't already have the `MemberByIdQuery` you don't need to override the `MemberById` method as you don't need to alter the `GraphQLName` which is the name of the query in the schema. This defaults to the query names you would normally use when using the query. (In this example `MemberById`)
+
+3. Register the query in Nikcio.UHeadless:
+
+```csharp
+.AddUHeadless(options =>
+{
+    options.AddQuery<CustomMemberItemExampleQuery>();
+})
+```
+
+4. Open `/graphql` and observe your new model for the `CustomMemberItemExampleQuery` query.

--- a/docs/src/content/docs/v12/extending/properties/block-list.md
+++ b/docs/src/content/docs/v12/extending/properties/block-list.md
@@ -1,0 +1,109 @@
+---
+title: Extending the Block list model in Nikcio.UHeadless
+description: Learn how to extend the block list model in Nikcio.UHeadless.
+---
+
+Nikcio.UHeadless provides flexibility to extend and replace the block list model to accommodate your specific needs.
+
+## Example
+
+1. Create your block list model:
+
+```csharp
+using HotChocolate;
+using HotChocolate.Resolvers;
+
+namespace Code.Examples.Headless.CustomBlockListExample;
+
+[GraphQLName("CustomBlockList")]
+public class BlockList : Nikcio.UHeadless.Defaults.Properties.BlockList<BlockListItem>
+{
+    public BlockList(CreateCommand command) : base(command)
+    {
+    }
+
+    protected override BlockListItem CreateBlock(Umbraco.Cms.Core.Models.Blocks.BlockListItem blockListItem, IResolverContext resolverContext)
+    {
+        return new BlockListItem(blockListItem, resolverContext);
+    }
+
+    public string? CustomProperty => "Custom value";
+
+    public string? CustomMethod()
+    {
+        return "Custom method";
+    }
+
+    public string? CustomMethodWithParameter(string? parameter)
+    {
+        return $"Custom method with parameter: {parameter}";
+    }
+
+    public string? CustomMethodWithResolverContext(IResolverContext resolverContext)
+    {
+        ArgumentNullException.ThrowIfNull(resolverContext);
+
+        IHttpContextAccessor httpContextAccessor = resolverContext.Service<IHttpContextAccessor>();
+
+        return $"Custom method with resolver context so you can resolve the services needed: {httpContextAccessor.HttpContext?.Request.Path}";
+    }
+}
+
+public class BlockListItem : Nikcio.UHeadless.Defaults.Properties.BlockListItem
+{
+    public BlockListItem(Umbraco.Cms.Core.Models.Blocks.BlockListItem blockListItem, IResolverContext resolverContext) : base(blockListItem, resolverContext)
+    {
+    }
+
+    public string? CustomProperty => "Custom value";
+
+    public string? CustomMethod()
+    {
+        return "Custom method";
+    }
+
+    public string? CustomMethodWithParameter(string? parameter)
+    {
+        return $"Custom method with parameter: {parameter}";
+    }
+
+    public string? CustomMethodWithResolverContext(IResolverContext resolverContext)
+    {
+        ArgumentNullException.ThrowIfNull(resolverContext);
+
+        IHttpContextAccessor httpContextAccessor = resolverContext.Service<IHttpContextAccessor>();
+
+        return $"Custom method with resolver context so you can resolve the services needed: {httpContextAccessor.HttpContext?.Request.Path}";
+    }
+}
+
+```
+
+2. Register the model in the UHeadless options:
+
+```csharp
+.AddUHeadless(options =>
+{
+    options.AddEditorMapping<BlockList>(Constants.PropertyEditors.Aliases.BlockList);
+})
+```
+
+There are two methods available to register the model in the UHeadless options:
+
+| Method Name       | Description                                                                    |
+|-------------------|--------------------------------------------------------------------------------|
+| AddAliasMapping   | Adds a mapping of a type to a content type alias and property type alias.      |
+| AddEditorMapping  | Adds a mapping of a type to an editor alias.                                   |
+
+
+## Resolver context extensions
+
+The `IResolverContext` contains the following extensions that can be used to get information about the current query:
+
+| Extension Name       | Description                                                                                                                      |
+|----------------------|----------------------------------------------------------------------------------------------------------------------------------|
+| IncludePreview()     | Gets whether to include preview content in the query.                                                                            |
+| Culture()            | Gets the culture of the query.                                                                                                   |
+| Segment()            | Gets the segment of the query.                                                                                                   |
+| Fallback()           | Gets the fallback of the query to be used for property values.                                                                   |
+| PublishedContent()   |Gets the published content from the scoped data. This can be different depending on where in the query resolution the code runs.  |

--- a/docs/src/content/docs/v12/extending/properties/custom-editor.md
+++ b/docs/src/content/docs/v12/extending/properties/custom-editor.md
@@ -1,0 +1,58 @@
+---
+title: Adding your custom editor model in Nikcio.UHeadless
+description: Learn how to add your custom editor model in Nikcio.UHeadless.
+---
+
+Nikcio.UHeadless provides flexibility to add your models for custom property editors.
+
+## Example
+
+1. Create your custom editor model:
+
+```csharp
+using HotChocolate.Resolvers;
+using Nikcio.UHeadless;
+using Nikcio.UHeadless.Common.Properties;
+
+public class CustomEditor : PropertyValue
+{
+    public CustomEditor(CreateCommand command) : base(command)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        IResolverContext resolverContext = command.ResolverContext;
+        Value = PublishedProperty.Value<string>(PublishedValueFallback, resolverContext.Culture(), resolverContext.Segment(), resolverContext.Fallback());
+    }
+
+    public string? Value { get; }
+}
+```
+
+2. Register the model in the UHeadless options:
+
+```csharp
+.AddUHeadless(options =>
+{
+    options.AddEditorMapping<CustomEditor>("customEditorAlias");
+})
+```
+
+There are two methods available to register the model in the UHeadless options:
+
+| Method Name       | Description                                                                    |
+|-------------------|--------------------------------------------------------------------------------|
+| AddAliasMapping   | Adds a mapping of a type to a content type alias and property type alias.      |
+| AddEditorMapping  | Adds a mapping of a type to an editor alias.                                   |
+
+
+## Resolver context extensions
+
+The `IResolverContext` contains the following extensions that can be used to get information about the current query:
+
+| Extension Name       | Description                                                                                                                      |
+|----------------------|----------------------------------------------------------------------------------------------------------------------------------|
+| IncludePreview()     | Gets whether to include preview content in the query.                                                                            |
+| Culture()            | Gets the culture of the query.                                                                                                   |
+| Segment()            | Gets the segment of the query.                                                                                                   |
+| Fallback()           | Gets the fallback of the query to be used for property values.                                                                   |
+| PublishedContent()   |Gets the published content from the scoped data. This can be different depending on where in the query resolution the code runs.  |

--- a/docs/src/content/docs/v12/extending/properties/media-picker.md
+++ b/docs/src/content/docs/v12/extending/properties/media-picker.md
@@ -1,0 +1,105 @@
+---
+title: Extending the Media Picker model in Nikcio.UHeadless
+description: Learn how to extend the media picker model in Nikcio.UHeadless.
+---
+
+Nikcio.UHeadless provides flexibility to extend and replace the media picker model to accommodate your specific needs.
+
+## Example 1
+
+1. Create your own media picker model:
+
+```csharp
+using HotChocolate.Resolvers;
+using Umbraco.Cms.Core.Models.PublishedContent;
+
+namespace Code.Examples.Headless.CustomMediaPickerExample;
+
+public class MediaPicker : Nikcio.UHeadless.Defaults.Properties.MediaPicker<MediaPickerItem>
+{
+    public MediaPicker(CreateCommand command) : base(command)
+    {
+    }
+
+    protected override MediaPickerItem CreateMediaPickerItem(IPublishedContent publishedContent, IResolverContext resolverContext)
+    {
+        return new MediaPickerItem(publishedContent, resolverContext);
+    }
+    public string? CustomProperty => "Custom value";
+
+    public string? CustomMethod()
+    {
+        return "Custom method";
+    }
+
+    public string? CustomMethodWithParameter(string? parameter)
+    {
+        return $"Custom method with parameter: {parameter}";
+    }
+
+    public string? CustomMethodWithResolverContext(IResolverContext resolverContext)
+    {
+        ArgumentNullException.ThrowIfNull(resolverContext);
+
+        IHttpContextAccessor httpContextAccessor = resolverContext.Service<IHttpContextAccessor>();
+
+        return $"Custom method with resolver context so you can resolve the services needed: {httpContextAccessor.HttpContext?.Request.Path}";
+    }
+}
+
+public class MediaPickerItem : Nikcio.UHeadless.Defaults.Properties.MediaPickerItem
+{
+    public MediaPickerItem(IPublishedContent publishedContent, IResolverContext resolverContext) : base(publishedContent, resolverContext)
+    {
+    }
+    public string? CustomProperty => "Custom value";
+
+    public string? CustomMethod()
+    {
+        return "Custom method";
+    }
+
+    public string? CustomMethodWithParameter(string? parameter)
+    {
+        return $"Custom method with parameter: {parameter}";
+    }
+
+    public string? CustomMethodWithResolverContext(IResolverContext resolverContext)
+    {
+        ArgumentNullException.ThrowIfNull(resolverContext);
+
+        IHttpContextAccessor httpContextAccessor = resolverContext.Service<IHttpContextAccessor>();
+
+        return $"Custom method with resolver context so you can resolve the services needed: {httpContextAccessor.HttpContext?.Request.Path}";
+    }
+}
+```
+
+2. Register the model in the UHeadless options:
+
+```csharp
+.AddUHeadless(options =>
+{
+    options.AddEditorMapping<MediaPicker>(Constants.PropertyEditors.Aliases.MediaPicker);
+})
+```
+
+There are two methods available to register the model in the UHeadless options:
+
+| Method Name       | Description                                                                    |
+|-------------------|--------------------------------------------------------------------------------|
+| AddAliasMapping   | Adds a mapping of a type to a content type alias and property type alias.      |
+| AddEditorMapping  | Adds a mapping of a type to an editor alias.                                   |
+
+
+## Resolver context extensions
+
+The `IResolverContext` contains the following extensions that can be used to get information about the current query:
+
+| Extension Name       | Description                                                                                                                      |
+|----------------------|----------------------------------------------------------------------------------------------------------------------------------|
+| IncludePreview()     | Gets whether to include preview content in the query.                                                                            |
+| Culture()            | Gets the culture of the query.                                                                                                   |
+| Segment()            | Gets the segment of the query.                                                                                                   |
+| Fallback()           | Gets the fallback of the query to be used for property values.                                                                   |
+| PublishedContent()   |Gets the published content from the scoped data. This can be different depending on where in the query resolution the code runs.  |

--- a/docs/src/content/docs/v12/extending/properties/overview.md
+++ b/docs/src/content/docs/v12/extending/properties/overview.md
@@ -1,0 +1,49 @@
+---
+title: Nikcio.UHeadless Extension Documentation
+description: Get an overview of the Nikcio.UHeadless extension documentation.
+---
+
+Welcome to the Nikcio.UHeadless Extension Documentation! Here, you'll find resources to help you extend and customize various features of Nikcio.UHeadless. Please select the topic you want to explore:
+
+- [Block List](./block-list): Learn how to extend and replace the block list property with your custom implementation.
+- [Custom Editor](./custom-editor): Discover how to create and integrate your custom editor for property values.
+- [Media Picker](./media-picker): Find out how to extend and customize the media picker data.
+- [Rich Text](./rich-text): Learn how to extend and replace the rich text editor with your custom implementation.
+
+## Dependency Injection
+
+Dependency injection is supported via the `IResolverContext` which is available on the command in the contructor of the property model. This allows you to resolve services and other dependencies needed for your custom implementation.
+
+You can also inject the `IResolverContext` into methods on the property model to resolve services and other dependencies needed for your custom implementation.
+
+### Examples
+
+```csharp
+public CustomEditor(CreateCommand command) : base(command)
+{
+    IHttpContextAccessor httpContextAccessor = resolverContext.Service<IHttpContextAccessor>();
+}
+```
+
+```csharp
+public string? CustomMethodWithResolverContext(IResolverContext resolverContext)
+{
+    ArgumentNullException.ThrowIfNull(resolverContext);
+
+    IHttpContextAccessor httpContextAccessor = resolverContext.Service<IHttpContextAccessor>();
+
+    return $"Custom method with resolver context so you can resolve the services needed: {httpContextAccessor.HttpContext?.Request.Path}";
+}
+```
+
+## Resolver context extensions
+
+The `IResolverContext` contains the following extensions that can be used to get information about the current query:
+
+| Extension Name       | Description                                                                                                                      |
+|----------------------|----------------------------------------------------------------------------------------------------------------------------------|
+| IncludePreview()     | Gets whether to include preview content in the query.                                                                            |
+| Culture()            | Gets the culture of the query.                                                                                                   |
+| Segment()            | Gets the segment of the query.                                                                                                   |
+| Fallback()           | Gets the fallback of the query to be used for property values.                                                                   |
+| PublishedContent()   |Gets the published content from the scoped data. This can be different depending on where in the query resolution the code runs.  |

--- a/docs/src/content/docs/v12/extending/properties/rich-text.md
+++ b/docs/src/content/docs/v12/extending/properties/rich-text.md
@@ -1,0 +1,74 @@
+---
+title: Extending the Rich text model in Nikcio.UHeadless
+description: Learn how to extend the rich text model in Nikcio.UHeadless.
+---
+
+Nikcio.UHeadless provides flexibility to extend and replace the rich text model to accommodate your specific needs.
+
+## Example
+
+1. Create your rich text model:
+
+```csharp
+using HotChocolate;
+using HotChocolate.Resolvers;
+
+namespace Code.Examples.Headless.CustomRichTextExample;
+
+[GraphQLName("CustomRichText")]
+public class RichText : Nikcio.UHeadless.Defaults.Properties.RichText
+{
+    public RichText(CreateCommand command) : base(command)
+    {
+    }
+    public string? CustomProperty => "Custom value";
+
+    public string? CustomMethod()
+    {
+        return "Custom method";
+    }
+
+    public string? CustomMethodWithParameter(string? parameter)
+    {
+        return $"Custom method with parameter: {parameter}";
+    }
+
+    public string? CustomMethodWithResolverContext(IResolverContext resolverContext)
+    {
+        ArgumentNullException.ThrowIfNull(resolverContext);
+
+        IHttpContextAccessor httpContextAccessor = resolverContext.Service<IHttpContextAccessor>();
+
+        return $"Custom method with resolver context so you can resolve the services needed: {httpContextAccessor.HttpContext?.Request.Path}";
+    }
+}
+```
+
+2. Register the model in the UHeadless options:
+
+```csharp
+.AddUHeadless(options =>
+{
+    options.AddEditorMapping<RichText>(Constants.PropertyEditors.Aliases.TinyMce);
+})
+```
+
+There are two methods available to register the model in the UHeadless options:
+
+| Method Name       | Description                                                                    |
+|-------------------|--------------------------------------------------------------------------------|
+| AddAliasMapping   | Adds a mapping of a type to a content type alias and property type alias.      |
+| AddEditorMapping  | Adds a mapping of a type to an editor alias.                                   |
+
+
+## Resolver context extensions
+
+The `IResolverContext` contains the following extensions that can be used to get information about the current query:
+
+| Extension Name       | Description                                                                                                                      |
+|----------------------|----------------------------------------------------------------------------------------------------------------------------------|
+| IncludePreview()     | Gets whether to include preview content in the query.                                                                            |
+| Culture()            | Gets the culture of the query.                                                                                                   |
+| Segment()            | Gets the segment of the query.                                                                                                   |
+| Fallback()           | Gets the fallback of the query to be used for property values.                                                                   |
+| PublishedContent()   |Gets the published content from the scoped data. This can be different depending on where in the query resolution the code runs.  |

--- a/docs/src/content/docs/v12/extending/skybrud-redirects.md
+++ b/docs/src/content/docs/v12/extending/skybrud-redirects.md
@@ -1,0 +1,112 @@
+---
+title: Integrating Skybrud.Umbraco.Redirects in Nikcio.UHeadless
+description: Learn how to integrate Skybrud.Umbraco.Redirects in Nikcio.UHeadless.
+---
+
+The Nikcio.UHeadless package provides a way to integrate the Skybrud.Umbraco.Redirects package in your Umbraco Headless project. This allows you to query for content like you would usually do but with the added benefit of getting redirect information from SKybrud.Umbraco.Redirects.
+
+## Example
+
+:::note
+This example is based on `Skybrud.Umbraco.Redirects` version `13.0.4`
+:::
+
+### Step 1: Install the Skybrud.Umbraco.Redirects package
+
+First, you need to install the `Skybrud.Umbraco.Redirects` package. You can do this by running the following command in the Package Manager Console:
+
+```bash
+Install-Package Skybrud.Umbraco.Redirects
+```
+
+### Step 2: Create a query class
+
+```csharp
+using HotChocolate;
+using HotChocolate.Resolvers;
+using HotChocolate.Types;
+using Nikcio.UHeadless;
+using Nikcio.UHeadless.ContentItems;
+using Nikcio.UHeadless.Defaults.ContentItems;
+using Skybrud.Umbraco.Redirects.Models;
+using Skybrud.Umbraco.Redirects.Services;
+
+[ExtendObjectType(typeof(HotChocolateQueryObject))]
+public class SkybrudRedirectsExampleQuery : ContentByRouteQuery
+{
+    [GraphQLName("skybrudRedirectsExampleQuery")]
+    public override Task<ContentItem?> ContentByRouteAsync(
+        IResolverContext resolverContext,
+        [GraphQLDescription("The route to fetch. Example '/da/frontpage/'.")] string route,
+        [GraphQLDescription("The base url for the request. Example: 'https://localhost:4000'. Default is the current domain")] string baseUrl = "",
+        [GraphQLDescription("The context of the request.")] QueryContext? inContext = null)
+    {
+        return base.ContentByRouteAsync(resolverContext, route, baseUrl, inContext);
+    }
+
+    protected override async Task<ContentItem?> CreateContentItemFromRouteAsync(IResolverContext resolverContext, string route, string baseUrl)
+    {
+        ArgumentNullException.ThrowIfNull(resolverContext);
+        ArgumentNullException.ThrowIfNull(baseUrl);
+
+        IRedirectsService redirectService = resolverContext.Service<IRedirectsService>();
+
+        var uri = new Uri($"{baseUrl.TrimEnd('/')}{route}");
+        IRedirect? redirect = redirectService.GetRedirectByUri(uri);
+
+        if (redirect != null)
+        {
+            IContentItemRepository<ContentItem> contentItemRepository = resolverContext.Service<IContentItemRepository<ContentItem>>();
+
+            string redirectUrl = redirect.Destination.FullUrl;
+
+            if (redirect.ForwardQueryString)
+            {
+                redirectUrl = redirectUrl.TrimEnd('/') + uri.Query;
+            }
+
+            return contentItemRepository.GetContentItem(new ContentItem.CreateCommand()
+            {
+                PublishedContent = null,
+                ResolverContext = resolverContext,
+                Redirect = new()
+                {
+                    IsPermanent = redirect.IsPermanent,
+                    RedirectUrl = redirectUrl,
+                },
+                StatusCode = redirect.IsPermanent ? StatusCodes.Status301MovedPermanently : StatusCodes.Status307TemporaryRedirect,
+            });
+        }
+
+        return await base.CreateContentItemFromRouteAsync(resolverContext, route, baseUrl).ConfigureAwait(false);
+    }
+}
+```
+
+This query class extends the `ContentByRouteQuery` query and overrides the `CreateContentItemFromRouteAsync` method. This method is called when a content item is fetched by route. In this method, we get the `IRedirectsService` from the `IResolverContext` and fetch the redirect for the route. If a redirect is found, we create a new `ContentItem` with the redirect information.
+
+### Step 3: Add the query to the UHeadless configuration
+
+```csharp
+.AddUHeadless(options =>
+{
+    options.AddQuery<SkybrudRedirectsExampleQuery>();
+})
+```
+
+### Step 4: Query the content
+
+Now you can query the content by route and get the redirect information:
+
+```graphql
+query {
+  skybrudRedirectsExampleQuery(baseUrl: "", route: "/") {
+    redirect {
+      isPermanent
+      redirectUrl
+    }
+  }
+}
+```
+
+This will return the redirect information if a redirect is found for the route. If no redirect is found, the content item will be fetched as usual.

--- a/docs/src/content/docs/v12/extending/url-tracker.md
+++ b/docs/src/content/docs/v12/extending/url-tracker.md
@@ -1,0 +1,288 @@
+---
+title: Integrating UrlTracker in Nikcio.UHeadless
+description: Learn how to integrate UrlTracker in Nikcio.UHeadless.
+---
+
+The Nikcio.UHeadless package provides a way to integrate the UrlTracker package into your UHeadless project. This allows you to use the UrlTracker package for redirects in your UHeadless project.
+
+## Example
+
+:::note
+This example is based on `UrlTracker` version `13.2.0-alpha0003`
+:::
+
+### Step 1: Install the UrlTracker package
+
+First, you need to install the `UrlTracker` package. You can do this by running the following command in the Package Manager Console:
+
+```bash
+Install-Package UrlTracker
+```
+
+### Step 2: Create a query class
+
+```csharp
+using System.Text.RegularExpressions;
+using HotChocolate;
+using HotChocolate.Resolvers;
+using HotChocolate.Types;
+using Microsoft.Extensions.Options;
+using Nikcio.UHeadless;
+using Nikcio.UHeadless.ContentItems;
+using Nikcio.UHeadless.Defaults.ContentItems;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Cms.Core.Routing;
+using UrlTracker.Core;
+using UrlTracker.Core.Intercepting.Models;
+using UrlTracker.Core.Models;
+using UrlTracker.Web.Processing;
+
+namespace Code.Examples.Headless.UrlTrackerExample;
+
+[ExtendObjectType(typeof(HotChocolateQueryObject))]
+public class UrlTrackerExampleQuery : ContentByRouteQuery
+{
+    [GraphQLName("urlTrackerExampleQuery")]
+    public override Task<ContentItem?> ContentByRouteAsync(
+        IResolverContext resolverContext,
+        [GraphQLDescription("The route to fetch. Example '/da/frontpage/'.")] string route,
+        [GraphQLDescription("The base url for the request. Example: 'https://localhost:4000'. Default is the current domain")] string baseUrl = "",
+        [GraphQLDescription("The context of the request.")] QueryContext? inContext = null)
+    {
+        return base.ContentByRouteAsync(resolverContext, route, baseUrl, inContext);
+    }
+
+    protected override async Task<ContentItem?> CreateContentItemFromRouteAsync(IResolverContext resolverContext, string route, string baseUrl)
+    {
+        ArgumentNullException.ThrowIfNull(resolverContext);
+        ArgumentNullException.ThrowIfNull(baseUrl);
+
+        IRequestInterceptFilterCollection requestInterceptFilters = resolverContext.Service<IRequestInterceptFilterCollection>();
+
+        var requestedUrl = Url.Parse($"{baseUrl.TrimEnd('/')}{route}");
+
+        if (!await requestInterceptFilters.EvaluateCandidateAsync(requestedUrl).ConfigureAwait(false))
+        {
+            return await base.CreateContentItemFromRouteAsync(resolverContext, route, baseUrl).ConfigureAwait(false);
+        }
+
+        IInterceptService interceptService = resolverContext.Service<IInterceptService>();
+
+        IIntercept intercept = await interceptService.GetAsync(requestedUrl).ConfigureAwait(false);
+
+        if (intercept.Info is not Redirect redirect)
+        {
+            return await base.CreateContentItemFromRouteAsync(resolverContext, route, baseUrl).ConfigureAwait(false);
+        }
+
+        IContentItemRepository<ContentItem> contentItemRepository = resolverContext.Service<IContentItemRepository<ContentItem>>();
+
+        string? redirectUrl = redirect.Target switch
+        {
+
+            UrlTargetStrategy target => GetUrl(resolverContext, redirect, target, requestedUrl),
+            ContentPageTargetStrategy target => GetUrl(resolverContext, redirect, target, requestedUrl),
+            _ => throw new NotImplementedException(),
+        };
+
+        return contentItemRepository.GetContentItem(new ContentItem.CreateCommand()
+        {
+            PublishedContent = null,
+            ResolverContext = resolverContext,
+            Redirect = new()
+            {
+                IsPermanent = redirect.Permanent,
+                RedirectUrl = redirectUrl,
+            },
+            StatusCode = redirectUrl == null ? StatusCodes.Status410Gone : GetStatusCode(redirect),
+        });
+    }
+
+    private static int GetStatusCode(Redirect redirect)
+    {
+        return redirect.Permanent ? StatusCodes.Status301MovedPermanently : StatusCodes.Status307TemporaryRedirect;
+    }
+
+    private static string? GetUrl(IResolverContext resolverContext, Redirect redirect, UrlTargetStrategy target, Url requestedUrl)
+    {
+        string urlString = target.Url;
+
+        if (redirect.Source is RegexSourceStrategy regexsource)
+        {
+            urlString = Regex.Replace((requestedUrl.Path + requestedUrl.Query).TrimStart('/'), regexsource.Value, urlString, RegexOptions.None, TimeSpan.FromMilliseconds(100));
+        }
+
+        var url = Url.Parse(urlString);
+
+        if (redirect.RetainQuery)
+        {
+            url.Query = requestedUrl.Query;
+        }
+
+        if (url.AvailableUrlTypes.Contains(UrlTracker.Core.Models.UrlType.Absolute))
+        {
+            RequestHandlerSettings requestHandlerSettingsValue = resolverContext.Service<IOptions<RequestHandlerSettings>>().Value;
+            return url.ToString(UrlTracker.Core.Models.UrlType.Absolute, requestHandlerSettingsValue.AddTrailingSlash);
+        }
+        else
+        {
+            return url.ToString();
+        }
+    }
+
+    private static string? GetUrl(IResolverContext resolverContext, Redirect redirect, ContentPageTargetStrategy target, Url requestedUrl)
+    {
+        if (target.Content is null)
+        {
+            return null;
+        }
+
+        IPublishedUrlProvider publishedUrlProvider = resolverContext.Service<IPublishedUrlProvider>();
+        var url = Url.Parse(target.Content.Url(publishedUrlProvider, target.Culture.DefaultIfNullOrWhiteSpace(null), UrlMode.Absolute));
+
+        if (redirect.RetainQuery)
+        {
+            url.Query = requestedUrl.Query;
+        }
+
+        if (url.AvailableUrlTypes.Contains(UrlTracker.Core.Models.UrlType.Absolute))
+        {
+            RequestHandlerSettings requestHandlerSettingsValue = resolverContext.Service<IOptions<RequestHandlerSettings>>().Value;
+            return url.ToString(UrlTracker.Core.Models.UrlType.Absolute, requestHandlerSettingsValue.AddTrailingSlash);
+        }
+        else
+        {
+            return url.ToString();
+        }
+    }
+}
+```
+
+This query class extends the `ContentByRouteQuery` query and overrides the `CreateContentItemFromRouteAsync` method. This method is called when a content item is fetched by route. In this method, we get the `IInterceptService` from the `IResolverContext` and fetch the redirect for the route. If a redirect is found, we create a new `ContentItem` with the redirect information.
+
+### Step 3: Register the query class
+
+```csharp
+.AddUHeadless(options =>
+{
+    options.AddQuery<UrlTrackerExampleQuery>();
+})
+```
+
+### Step 4: Query the content
+
+Now you can query the content by route and get the redirect information:
+
+```graphql
+query {
+  urlTrackerExampleQuery(baseUrl: "", route: "/") {
+    redirect {
+      isPermanent
+      redirectUrl
+    }
+  }
+}
+```
+
+## Track error status codes
+
+The UrlTracker package also allows you to track error status codes to get recommendations about missing redirects. You can create a mutation to track these error status codes from your frontend like this:
+
+```csharp
+using HotChocolate;
+using HotChocolate.Resolvers;
+using HotChocolate.Types;
+using Nikcio.UHeadless;
+using Nikcio.UHeadless.Defaults.Authorization;
+using UrlTracker.Middleware.Background;
+
+namespace Code.Examples.Headless.UrlTrackerExample;
+
+[ExtendObjectType(typeof(HotChocolateMutationObject))]
+public class TrackErrorStatusCodeMutation : IGraphQLMutation
+{
+    public const string PolicyName = "TrackErrorStatusCode";
+
+    public const string ClaimValue = "track.error.statuscode.mutation";
+
+    [GraphQLIgnore]
+    public virtual void ApplyConfiguration(UHeadlessOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        options.UmbracoBuilder.Services.AddAuthorizationBuilder().AddPolicy(PolicyName, policy =>
+        {
+            if (options.DisableAuthorization)
+            {
+                policy.AddRequirements(new AlwaysAllowAuthoriaztionRequirement());
+                return;
+            }
+
+            policy.AddAuthenticationSchemes(DefaultAuthenticationSchemes.UHeadless);
+
+            policy.RequireAuthenticatedUser();
+
+            policy.RequireClaim(DefaultClaims.UHeadlessScope, ClaimValue);
+        });
+    }
+
+    public async Task<TrackErrorStatusCodeResponse> TrackErrorStatusCodeAsync(
+        IResolverContext resolverContext,
+        [GraphQLDescription("Status code of the client error.")] int statusCode,
+        [GraphQLDescription("The URL that generated the client error.")] string url,
+        [GraphQLDescription("The time and date at which the client error was generated")] DateTime timestamp,
+        [GraphQLDescription("The URL from which the current URL is requested")] string? referrer)
+    {
+        ArgumentNullException.ThrowIfNull(resolverContext);
+
+        ILogger<TrackErrorStatusCodeMutation> logger = resolverContext.Service<ILogger<TrackErrorStatusCodeMutation>>();
+        switch (statusCode)
+        {
+            case StatusCodes.Status404NotFound:
+                IClientErrorProcessorQueue clientErrorProcessorQueue = resolverContext.Service<IClientErrorProcessorQueue>();
+                await clientErrorProcessorQueue.WriteAsync(new ClientErrorProcessorItem(url, timestamp, referrer)).ConfigureAwait(false);
+                break;
+            case StatusCodes.Status500InternalServerError:
+                logger.LogError("Internal server error occurred at {Timestamp} for URL {Url} with referrer {Referrer}", timestamp, url, referrer);
+                break;
+            default:
+                logger.LogWarning("Client error occurred at {Timestamp} for URL {Url} with referrer {Referrer} and status code {StatusCode}", timestamp, url, referrer, statusCode);
+                break;
+        }
+        
+        return new TrackErrorStatusCodeResponse
+        {
+            Success = true
+        };
+    }
+}
+
+public sealed class TrackErrorStatusCodeResponse
+{
+    public required bool Success { get; init; }
+}
+```
+
+This mutation class allows you to track error status codes from your frontend. You can use this mutation to track client errors like `404` and `500` errors. You can also track the time and date at which the client error was generated and the URL from which the current URL is requested.
+
+### Register the mutation class
+
+```csharp
+.AddUHeadless(options =>
+{
+    options.AddMutation<TrackErrorStatusCodeMutation>();
+})
+```
+
+### Query the mutation
+
+Now you can query the mutation to track the error status codes:
+
+```graphql
+mutation {
+  trackErrorStatusCode(statusCode: 404, url: "https://my-website.com/page-not-found", timestamp: "2022-01-01T00:00:00Z", referrer: "https://my-website.com") {
+    success
+  }
+}
+```

--- a/docs/src/content/docs/v12/fundamentals/getting-started.md
+++ b/docs/src/content/docs/v12/fundamentals/getting-started.md
@@ -1,0 +1,146 @@
+---
+title: Getting Started with Nikcio.UHeadless
+description: Learn how to get started with Nikcio.UHeadless.
+---
+
+This guide will walk you through the process of integrating Nikcio.UHeadless into your Umbraco solution. By following these steps, you'll be able to create a headless GraphQL interface for your Umbraco CMS.
+
+## Installation
+
+To get started, follow the steps below:
+
+### Step 1: Install the package
+
+Install the Nikcio.UHeadless package using the following command:
+
+```shell
+dotnet add Nikcio.UHeadless
+```
+
+### Step 2: Add the extensions to the `Program.cs` file
+
+In your `Program.cs` file, add the necessary extensions by following the code snippet below:
+
+Namespaces:
+
+```csharp
+using Nikcio.UHeadless;
+using Nikcio.UHeadless.Defaults.ContentItems;
+```
+
+On the `UmbracoBuilder`, add the following code:
+
+```csharp
+builder.CreateUmbracoBuilder()
+    // Default Umbraco configuration
+    .AddUHeadless(options =>
+    {
+        options.DisableAuthorization = true; // Change this later when adding authentication - See documentation
+
+        options.AddDefaults();
+
+        options.AddQuery<ContentByRouteQuery>();
+        options.AddQuery<ContentByGuidQuery>();
+    })
+    .Build();
+```
+
+Then after the `app.BootUmbracoAsync()` method, add the following code:
+
+```csharp
+await app.BootUmbracoAsync();
+
+app.UseAuthentication();
+app.UseAuthorization();
+
+GraphQLEndpointConventionBuilder graphQLEndpointBuilder = app.MapUHeadless();
+
+// Only enable the GraphQL IDE in development
+if (!builder.Environment.IsDevelopment())
+{
+    graphQLEndpointBuilder.WithOptions(new GraphQLServerOptions()
+    {
+        Tool =
+        {
+            Enable = false,
+        }
+    });
+}
+
+app.UseUmbraco()
+    // Default Umbraco configuration
+```
+
+The `.AddUHeadless()` method adds the services needed for Nikcio.UHeadless to run, while `app.MapUHeadless()` adds the endpoint from where you interact with the GraphQL interface. These extensions provide a range of options that can be customized. To learn more about available options, refer to the [UHeadless options](../reference/options) and [UHeadless endpoint options](../reference/endpoint-options) documentation.
+
+### Step 3: Find the GraphQL endpoint
+
+By default, the GraphQL endpoint can be accessed at `/graphql` in your application.
+
+### Step 4: Make your first query
+
+To get started, try querying your content using their GUIDs or routes. For example with the query below:
+
+__Tip: GUIDs can be found in the info tab when viewing content in the backoffice__
+
+```graphql
+query {
+  contentByGuid(id: "dcf18a51-6919-4cf8-89d1-36b94ce4d963") {
+    id
+    key
+    name
+    statusCode
+    templateId
+    updateDate
+    url(urlMode: ABSOLUTE)
+    urlSegment
+  }
+}
+```
+
+This query fetches a content item with the given GUID.
+
+Congratulations! You have successfully integrated Nikcio.UHeadless into your Umbraco solution. 
+
+## Adding a more queries
+
+To add a more queries to Nikcio.UHeadless, you can include the following code in your `Program.cs` file:
+
+```csharp
+.AddUHeadless(options =>
+{
+    // Existing configuration
+
+    options.AddQuery<ContentByIdQuery>();
+})
+```
+
+This example demonstrates how to add the `ContentByIdQuery` query to Nikcio.UHeadless. By including this code, you will enable the ability to query a content item by the numeric ID instead of the GUID:
+
+```graphql
+query {
+  contentById(id: 1050) {
+    id
+    key
+    name
+    statusCode
+    templateId
+    updateDate
+    url(urlMode: ABSOLUTE)
+    urlSegment
+  }
+}
+```
+
+To explore the available queries and how to use them, refer to the following documentation:
+
+- [Learn how to query properties](../querying/properties)
+- [Querying Content](../querying/content)
+- [Querying Media](../querying/media)
+- [Querying Members](../querying/members)
+
+## Next steps
+
+- [Security Considerations](../security)
+
+If you have any questions or need further assistance, don't hesitate to reach out to us. Happy coding with Nikcio.UHeadless

--- a/docs/src/content/docs/v12/fundamentals/querying/content.md
+++ b/docs/src/content/docs/v12/fundamentals/querying/content.md
@@ -1,0 +1,38 @@
+---
+title: Content Queries
+description: Learn how to query content in Nikcio.UHeadless.
+---
+
+The Nikcio.UHeadless package provides various content queries that allow you to retrieve content items in different ways from Umbraco CMS.
+
+## Queries
+
+You can add any query to the UHeadless options as seen here:
+
+```csharp
+.AddUHeadless(options =>
+{
+    options.AddQuery<ContentByRouteQuery>();
+})
+```
+
+The following content queries are available:
+
+| Query class Name             | Description                                 | Needed claim values                                 |
+|------------------------------|---------------------------------------------|-----------------------------------------------------|
+| ContentAtRootQuery           | Gets all the content items at root level.   | content.at.root.query or global.content.read        |
+| ContentByContentTypeQuery    | Gets all the content items by content type. | content.by.contentType.query or global.content.read |
+| ContentByGuidQuery           | Gets a content item by Guid.                | content.by.guid.query or global.content.read        |
+| ContentByIdQuery             | Gets a content item by id.                  | content.by.id.query or global.content.read          |
+| ContentByRouteQuery          | Gets a content item by a route.             | content.by.route.query or global.content.read       |
+| ContentByTagQuery            | Gets content items by tag.                  | content.by.tag.query or global.content.read         |
+
+You can explore these queries and their parameters in the UI provided at `/graphql` when you have added them to the UHeadless options as seen above.
+
+The claim values are needed when having authorization enabled. You can read more about authorization and how to create tokens in the [Security Considerations](../security) section.
+
+A special case for claim values are for the member picker editor. To access the data of the member picker you will need one of the following claim values: `property.values.member.picker` or `global.member.read`.
+
+## Next steps
+
+- [Building your property query](./properties)

--- a/docs/src/content/docs/v12/fundamentals/querying/media.md
+++ b/docs/src/content/docs/v12/fundamentals/querying/media.md
@@ -1,0 +1,36 @@
+---
+title: Media Queries
+description: Learn how to query media in Nikcio.UHeadless.
+---
+
+The Nikcio.UHeadless package provides various media queries that allow you to retrieve media items in different ways from Umbraco CMS.
+
+## Queries
+
+You can add any query to the UHeadless options as seen here:
+
+```csharp
+.AddUHeadless(options =>
+{
+    options.AddQuery<MediaByGuidQuery>();
+})
+```
+
+The following content queries are available:
+
+| Query class Name             | Description                                 | Needed claim values                                 |
+|------------------------------|---------------------------------------------|-----------------------------------------------------|
+| MediaAtRootQuery             | Gets all the media items at root level.     | media.at.root.query or global.media.read            |
+| MediaByContentTypeQuery      | Gets all the media items by content type.   | media.by.contentType.query or global.media.read     |
+| MediaByGuidQuery             | Gets a Media item by Guid.                  | media.by.guid.query or global.media.read            |
+| MediaByIdQuery               | Gets a Media item by id.                    | media.by.id.query or global.media.read              |
+
+You can explore these queries and their parameters in the UI provided at `/graphql` when you have added them to the UHeadless options as seen above.
+
+The claim values are needed when having authorization enabled. You can read more about authorization and how to create tokens in the [Security Considerations](../security) section.
+
+A special case for claim values are for the member picker editor. To access the data of the member picker you will need one of the following claim values: `property.values.member.picker` or `global.member.read`.
+
+## Next steps
+
+- [Building your property query](./properties)

--- a/docs/src/content/docs/v12/fundamentals/querying/members.md
+++ b/docs/src/content/docs/v12/fundamentals/querying/members.md
@@ -1,0 +1,41 @@
+---
+title: Member Queries
+description: Learn how to query members in Nikcio.UHeadless.
+---
+
+The Nikcio.UHeadless package provides various member queries that allow you to retrieve member data from Umbraco CMS.
+The Nikcio.UHeadless package provides various media queries that allow you to retrieve media items in different ways from Umbraco CMS.
+
+## Queries
+
+You can add any query to the UHeadless options as seen here:
+
+```csharp
+.AddUHeadless(options =>
+{
+    options.AddQuery<MemberByGuidQuery>();
+})
+```
+
+The following content queries are available:
+
+| Query class Name              | Description                                 | Needed claim values                                         |
+|-------------------------------|---------------------------------------------|-------------------------------------------------------------|
+| FindMembersByDisplayNameQuery | Finds members by display name.              | find.members.by.display.name.query or global.member.read    |
+| FindMembersByEmailQuery       | Finds members by email.                     | find.members.by.email.query or global.member.read           |
+| FindMembersByRoleQuery        | Finds members by role.                      | find.members.by.role.query or global.member.read            |
+| FindMembersByUsernameQuery    | Finds members by username.                  | find.members.by.username.query or global.member.read        |
+| MemberByEmailQuery            | Gets a member by email.                     | member.by.email.query or global.member.read                 |
+| MemberByGuidQuery             | Gets a member by Guid.                      | member.by.guid.query or global.member.read                  |
+| MemberByIdQuery               | Gets a member by id.                        | member.by.id.query or global.member.read                    |
+| MemberByUsernameQuery         | Gets a member by username.                  | member.by.username.query or global.member.read              |
+
+You can explore these queries and their parameters in the UI provided at `/graphql` when you have added them to the UHeadless options as seen above.
+
+The claim values are needed when having authorization enabled. You can read more about authorization and how to create tokens in the [Security Considerations](../security) section.
+
+A special case for claim values are for the member picker editor. To access the data of the member picker you will need one of the following claim values: `property.values.member.picker` or `global.member.read`.
+
+## Next steps
+
+- [Building your property query](./properties)

--- a/docs/src/content/docs/v12/fundamentals/querying/properties.md
+++ b/docs/src/content/docs/v12/fundamentals/querying/properties.md
@@ -1,0 +1,74 @@
+---
+title: Building Your Property Query
+description: Learn how to build your property query in Nikcio.UHeadless.
+---
+
+In GraphQL, queries are used to request specific data from a server. When building a property query in GraphQL, you can use fragments to organize and reuse common selections of fields. Fragments allow you to define a set of fields that can be included in multiple queries, reducing duplication and making queries more modular.
+
+## Quering properties
+
+To query properties you use a list of property aliases that you want to fetch. This is possible on content, media and member models. To query properties you use the content, content compositions, media or member types created in Umbraco. Example:
+
+```graphql
+query {
+  contentByRoute(baseUrl: "", route: "/") {
+    properties {
+      ... on IArticle {
+        title {
+          value
+        }
+        articleDate {
+          value
+        }
+        author {
+          items {
+            name
+          }
+        }
+      }
+      __typename
+    }
+  }
+}
+```
+
+This works by the properties getting the type of content your fetching and then fetching the properties based on that type. In this example we have created a content type called `Article` in Umbraco and if the content item we find with our query matches the `Article` type we fetch the properties `title`, `articleDate` and `author`. 
+
+The `__typename` field is used to get the type of the content item we fetch. This can help you figure out what properties are available on the content item you fetch. In this example if the `__typename` field returns `Article` we know that the properties `title`, `articleDate` and `author` are available on the content item.
+
+This is because all types of content, media and member types which have properties have a matching type and interface in the GraphQL schema.
+
+For this example we will see the following in the GraphQL schema:
+
+```graphql
+type Article implements IArticleControls & IContentControls & IHeaderControls & IMainImageControls & ISEOControls & IVisibilityControls & IArticle {
+
+# ... the fields of the type ...
+
+}
+```
+
+Here we can see that the `Article` type implements the `IArticle` interface. This means that we can fetch the properties of the `IArticle` interface on the `Article` type. This is why we can fetch the properties `title`, `articleDate` and `author` on the `Article` type.
+
+Other than is we can see multiple other interfaces that the `Article` type implements. This means that we can fetch the properties of those interfaces on the `Article` type as well. This is useful when you have compositions in Umbraco that you want to fetch properties from.
+
+For example we can see that the `IArticleControls` interface has the following properties:
+
+```graphql
+type ArticleControls implements IArticleControls {
+  """
+  Enter the date for the article
+  """
+  articleDate: DateTimePicker
+
+  author: ContentPicker
+
+  categories: ContentPicker
+}
+```
+
+This means that we can use a fragment selection on the `IArticleControls` interface to fetch the properties `articleDate`, `author` and `categories` on the any type that has this compostion in Umbraco.
+
+:::note
+When fetching properties you need to use the interfaces (They are prefixed with `I` on the type name) instead of the concrete types as the concrete types don't always return the expected values due to the matching rules in GraphQL.
+:::

--- a/docs/src/content/docs/v12/fundamentals/security.md
+++ b/docs/src/content/docs/v12/fundamentals/security.md
@@ -1,0 +1,313 @@
+---
+title: Security Considerations
+description: Learn about what areas to consider when securing your Nikcio.UHeadless application.
+---
+
+When using Nikcio.UHeadless, it is important to consider security measures to protect your GraphQL data and ensure that access to sensitive information is properly controlled. This section highlights some key security considerations and provides guidance on implementing security measures.
+
+## Using Authentication and Authorization in Nikcio.UHeadless
+
+To enable authentication and authorization in Nikcio.UHeadless follow the code example below:
+
+### Step 1: Configure the Services in the `Program.cs` file
+
+In the `AddUHeadless` options add the following code snippet:
+
+:::note
+The `.AddAuth()` call must be the first thing in the options
+:::
+
+```csharp
+.AddUHeadless(options =>
+{
+    options.AddAuth(new()
+    {
+        ApiKey = builder.Configuration.GetValue<string>("UHeadless:ApiKey") ?? throw new InvalidOperationException("No value for UHeadless:ApiKey was found"),
+        Secret = builder.Configuration.GetValue<string>("UHeadless:Secret") ?? throw new InvalidOperationException("No value for UHeadless:Secret was found"),
+    });
+
+    // Other configuration
+})
+```
+
+The `ApiKey` can be any value over 32 characters long. This value is used in the `X-UHeadless-Api-Key` header when creating tokens used for quering the GraphQL endpoint. 
+
+The `Secret` can be any value over 64 characters long. This value is used as the signing key when creating the JWT tokens used for quering the GraphQL endpoint.
+
+:::note
+You can provide the `ApiKey` and `Secret` from anywhere this example shows loading them from the `appsettings.json` file.
+:::
+
+Also make sure to add the following code snippet to the request pipeline after the `app.BootUmbracoAsync()` method:
+
+```csharp
+app.UseAuthentication();
+app.UseAuthorization();
+```
+
+### Step 2: Create a token for queries to the GraphQL endpoint
+
+Once the configuration above have been added all the default queries in the package will automatically be protected and require a token to be queried. To create a token run the application, go to `/graphql` and run the following query:
+
+```graphql
+mutation {
+  createToken(claims: [
+    {
+      name: "headless-scope",
+      value: "global.content.read"
+    }
+  ]) {
+    expires
+    header
+    prefix
+    token
+  }
+}
+```
+
+Make sure to include the `X-UHeadless-Api-Key` header with the value of the `ApiKey` you provided in the configuration. This will create a token that can query all content queries.
+
+![Create token example image](../../../../assets/v5/create-token-example-image.png)
+
+### Step 3: Use the token to query the GraphQL endpoint
+
+The `createToken` mutation will return a token in the following format:
+
+```json
+{
+  "data": {
+    "createToken": {
+      "expires": 1717883090,
+      "header": "X-UHeadless-Token",
+      "prefix": "Bearer ",
+      "token": "<TOKEN>"
+    }
+  }
+}
+```
+
+To query a query use the token provided along with the prefix in the header `X-UHeadless-Token` like so:
+
+```graphql
+query {
+  contentByRoute(baseUrl: "", route: "/") {
+    id
+    key
+    name
+    statusCode
+    templateId
+    updateDate
+    url(urlMode: ABSOLUTE)
+    urlSegment
+  }
+}
+```
+
+```text
+X-UHeadless-Token: Bearer eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJoZWFkbGVzcy1zY29wZSI6Imdsb2JhbC5jb250ZW50LnJlYWQiLCJleHAiOjE3MTc3OTIyMTYsImlzcyI6Ik5pa2Npby5VSGVhZGxlc3MiLCJhdWQiOiJOaWtjaW8uVUhlYWRsZXNzIn0.Iwis2EPUjk4uY9_ZyDLYg3NRs2lTh8S-7KEaVCQTFv6nKywMmZRiPMN4Fe2uanq44WqmzWeHRqOWhp5tCGHfKA
+```
+
+![Use token example image](../../../../assets/v5/use-token-example-image.png)
+
+Now you have successfully added authentication and authorization to your Nikcio.UHeadless application.
+
+## Different claims for different queries
+
+To create a token with different claims for different queries you can use the `createToken` mutation like so:
+
+```graphql
+mutation {
+  createToken(claims: [
+    {
+      name: "headless-scope",
+      value: ["global.content.read", "global.media.read"]
+    }
+  ]) {
+    expires
+    header
+    prefix
+    token
+  }
+}
+```
+
+or
+
+```graphql
+mutation {
+  createToken(claims: [
+    {
+      name: "headless-scope",
+      value: "global.content.read"
+    },
+    {
+      name: "headless-scope",
+      value: "global.media.read"
+    }
+  ]) {
+    expires
+    header
+    prefix
+    token
+  }
+}
+```
+
+There exists a few different claims in the default queries for UHeadless. What claims are required for each query can be found in the documentation for the query.
+
+See [content queries](../querying/content), [media queries](../querying/media) or [member queries](../querying/members) for more information.
+
+A special case for claim values are for the member picker editor. To access the data of the member picker you will need one of the following claim values: `property.values.member.picker` or `global.member.read`.
+
+## Adding security to your own queries
+
+If you have created your own queries you can add security to them by adding the policy configuration in the `ApplyConfiguration` method and adding the `[Authorize]` attribute from `HotChocolate.Authorization` to the query method like so:
+
+:::caution
+It's important to use the `[Authorize]` from `HotChocolate.Authorization` and not the one from `Microsoft.AspNetCore.Authorization` as the one from `HotChocolate.Authorization` is the one that works with HotChocolate and adding the other one will have no effect.
+:::
+
+```csharp
+using HotChocolate.Authorization;
+using Nikcio.UHeadless;
+using Nikcio.UHeadless.Defaults.Authorization;
+
+public class MyCustomQuery : IGraphQLQuery
+{
+    public const string PolicyName = "MyCustomQuery";
+
+    public const string ClaimValue = "my.custom.query";
+
+    [GraphQLIgnore]
+    public virtual void ApplyConfiguration(UHeadlessOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        options.UmbracoBuilder.Services.AddAuthorizationBuilder().AddPolicy(PolicyName, policy =>
+        {
+            policy.AddAuthenticationSchemes(DefaultAuthenticationSchemes.UHeadless);
+
+            policy.RequireAuthenticatedUser();
+
+            policy.RequireClaim(DefaultClaims.UHeadlessScope, ClaimValue);
+        });
+    }
+
+    [Authorize(Policy = PolicyName)]
+    [GraphQLDescription("My custom query.")]
+    public virtual List<string> MyQuery()
+    {
+        return ["Hello", "World"];
+    }
+}
+```
+
+## Utillty queries
+
+There is one utility query that can be used to find all default claims are used by the queries you have added to your application. This query is called `utility_GetClaimGroups` and can be used like so:
+
+:::note
+The `utility_GetClaimGroups` query is publicly accessible and should only be used for development purposes.
+:::
+
+```csharp
+.AddUHeadless(options =>
+{
+    options.AddQuery<UtilityClaimGroupsQuery>();
+})
+```
+
+Query:
+
+```graphql
+query {
+  utility_GetClaimGroups {
+    groupName
+    claimValues {
+      name
+      values
+    }
+  }
+}
+```
+
+Response example:
+
+```json
+{
+  "data": {
+    "utility_GetClaimGroups": [
+      {
+        "groupName": "Members",
+        "claimValues": [
+          {
+            "name": "headless-scope",
+            "values": [
+              "property.values.member.picker",
+              "global.member.read",
+              "find.members.by.display.name.query",
+              "find.members.by.email.query",
+              "find.members.by.role.query",
+              "find.members.by.username.query",
+              "member.by.email.query",
+              "member.by.guid.query",
+              "member.by.id.query",
+              "member.by.username.query"
+            ]
+          }
+        ]
+      },
+      {
+        "groupName": "Content",
+        "claimValues": [
+          {
+            "name": "headless-scope",
+            "values": [
+              "content.by.route.query",
+              "global.content.read",
+              "content.by.contentType.query",
+              "content.at.root.query",
+              "content.by.id.query",
+              "content.by.guid.query",
+              "content.by.tag.query"
+            ]
+          }
+        ]
+      },
+      {
+        "groupName": "Media",
+        "claimValues": [
+          {
+            "name": "headless-scope",
+            "values": [
+              "media.by.contentType.query",
+              "global.media.read",
+              "media.at.root.query",
+              "media.by.id.query",
+              "media.by.guid.query"
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+## HotChocolate Documentation
+
+Nikcio.UHeadless leverages the [HotChocolate](https://chillicream.com/docs/hotchocolate) NuGet package, which is a powerful GraphQL server implementation for .NET. HotChocolate provides documentation on various security topics, including how to add authentication and authorization to your GraphQL queries and data.
+
+For detailed insights into how the implementation works with HotChocolate, refer to the official HotChocolate documentation on security at:
+
+[HotChocolate Security Documentation](https://chillicream.com/docs/hotchocolate/security)
+
+This documentation covers different authentication and authorization mechanisms supported by HotChocolate and provides guidelines on securing your GraphQL API effectively.
+
+## Additional or Alternative Security Measures
+
+In addition to leveraging built-in security features and following best practices for authentication and authorization, you can implement additional security measures to protect your Nikcio.UHeadless GraphQL data. Here are some suggestions:
+
+One suggestion is to use a reverse proxy or similar technology to route all traffic to and from the `/graphql` endpoint internally. By configuring the reverse proxy to allow access only from trusted sources, you can ensure that your GraphQL data remains inaccessible to the public.
+
+Another suggestion is to only route GraphQL traffic server side to your FE application as this will prevent leaking access tokens to the client.

--- a/docs/src/content/docs/v12/reference/content.md
+++ b/docs/src/content/docs/v12/reference/content.md
@@ -1,0 +1,11 @@
+---
+title: Content bases reference
+description: Overview of content bases in Nikcio.UHeadless.
+---
+
+In Nikcio.UHeadless, content bases provide a way to create custom models that can be used in place of existing models. These bases allow you to define your own content data structure or extend the existing data structure.
+
+| Class Name        | Description                                                                    |
+|-------------------|--------------------------------------------------------------------------------|
+| ContentItemBase   | The lowest level for a content item. Contains no public properties             |
+| ContentItem       | The default model used for queries. This includes the most common properties   |

--- a/docs/src/content/docs/v12/reference/endpoint-options.md
+++ b/docs/src/content/docs/v12/reference/endpoint-options.md
@@ -1,0 +1,38 @@
+---
+title: Endpoint Options
+description: Overview of the endpoint options in Nikcio.UHeadless.
+---
+
+The UHeadless endpoint can be customized using the builder returned from the `.MapUHeadless()` method. The builder provides a number of options to configure the endpoint.
+
+## Disabling the GraphQL IDE in production
+
+```csharp
+GraphQLEndpointConventionBuilder graphQLEndpointBuilder = app.MapUHeadless();
+
+// Only enable the GraphQL IDE in development
+if (!builder.Environment.IsDevelopment())
+{
+    graphQLEndpointBuilder.WithOptions(new GraphQLServerOptions()
+    {
+        Tool =
+        {
+            Enable = false,
+        }
+    });
+}
+```
+
+## GraphQLServerOptions Properties
+
+| Property                                | Description                                                                                        |
+|-----------------------------------------|----------------------------------------------------------------------------------------------------|
+| Tool                                    | The options for configuring the GraphQL tool (e.g., Banana Cake Pop).                              |
+| Sockets                                 | The options for configuring GraphQL sockets.                                                       |
+| AllowedGetOperations                    | Specifies which GraphQL options are allowed on GET requests.                                       |
+| EnableGetRequests                       | Specifies whether GraphQL HTTP GET requests are allowed.                                           |
+| EnforceGetRequestsPreflightHeader       | Specifies whether to enforce the preflight header for GraphQL HTTP GET requests.                   |
+| EnableMultipartRequests                 | Specifies whether GraphQL HTTP multipart requests are allowed.                                     |
+| EnforceMultipartRequestsPreflightHeader | Specifies whether to enforce the preflight header for GraphQL HTTP multipart requests.             |
+| EnableSchemaRequests                    | Specifies whether the GraphQL schema SDL can be downloaded.                                        |
+| EnableBatching                          | Specifies whether request batching is enabled.                                                     |

--- a/docs/src/content/docs/v12/reference/media.md
+++ b/docs/src/content/docs/v12/reference/media.md
@@ -1,0 +1,11 @@
+---
+title: Media Bases reference
+description: Overview of media bases in Nikcio.UHeadless.
+---
+
+In Nikcio.UHeadless, media bases provide a way to create custom models that can be used in place of existing models. These bases allow you to define your own media data structure or extend the existing data structure.
+
+| Class Name        | Description                                                                    |
+|-------------------|--------------------------------------------------------------------------------|
+| MediaItemBase     | The lowest level for a media item. Contains no public properties               |
+| MediaItem         | The default model used for queries. This includes the most common properties   |

--- a/docs/src/content/docs/v12/reference/member.md
+++ b/docs/src/content/docs/v12/reference/member.md
@@ -1,0 +1,11 @@
+---
+title: Member Bases reference
+description: Overview of member bases in Nikcio.UHeadless.
+---
+
+In Nikcio.UHeadless, member bases provide a way to create custom models that can be used in place of existing models. These bases allow you to define your own member data structure or extend the existing data structure.
+
+| Class Name        | Description                                                                    |
+|-------------------|--------------------------------------------------------------------------------|
+| MemberBase        | The lowest level for a member item. Contains no public properties              |
+| MemberItem        | The default model used for queries. This includes the most common properties   |

--- a/docs/src/content/docs/v12/reference/options.md
+++ b/docs/src/content/docs/v12/reference/options.md
@@ -1,0 +1,27 @@
+---
+title: UHeadless Options
+description: Overview of the options in Nikcio.UHeadless.
+---
+
+The `UHeadlessOptions` class provides configuration options for the UHeadless package. These options can be used to customize various aspects of UHeadless behavior.
+
+## UHeadlessOptions Properties
+
+| Property                  | Description                                                                             |
+|---------------------------|-----------------------------------------------------------------------------------------|
+| PropertyMap               | Used to register custom models to specific property values.                             |
+| DisableAuthorization      | Disables authorization for the GraphQL server.                                          |
+| RequestExecutorBuilder    | Used to customize the GraphQL server.                                                   |
+
+## Extensions
+
+| Property               | Description                                                                                |
+|------------------------|--------------------------------------------------------------------------------------------|
+| AddDefaults            | Adds default property mappings and services to be used for the default queries.            |
+| AddAuth                | Adds the authentication services to the UHeadless package.                                 |
+| AddQuery               | Adds a query to the GraphQL schema                                                         |
+| AddMutation            | Adds a mutation to the GraphQL schema                                                      |
+| AddEditorMapping       | Adds a mapping of a type to a editor alias.                                                |
+| AddAliasMapping        | Adds a mapping of a type to a content type alias combined with a property type alias.      |
+| RemoveAliasMapping     | Removes a alias mapping                                                                    |
+| RemoveEditorMapping    | Removes a editor mapping                                                                   |

--- a/docs/src/content/docs/v12/reference/properties.md
+++ b/docs/src/content/docs/v12/reference/properties.md
@@ -1,0 +1,22 @@
+---
+title: Property models reference
+description: Overview of property models in Nikcio.UHeadless.
+---
+
+In Nikcio.UHeadless, property models can be extended and customized adding additional properties and functionality. The default property models provide a solid foundation for building custom property models. By extending these models, you can tailor them to your specific application requirements.
+
+| Class Name                                     | Description                                                                                       |
+|------------------------------------------------|---------------------------------------------------------------------------------------------------|
+| PropertyValue                                  | A base for property values. This is the lowest level of any property value.                       |
+| BlockGrid                                      | Represents a block grid property value                                                            |
+| BlockList                                      | Represents a block list model                                                                     |
+| ContentPicker                                  | Represents a content picker value                                                                 |
+| DateTimePicker                                 | Represents a date time property value                                                             |
+| DefaultProperty                                | A catch all property value that simply returns the value of the property. This is all that is needed for simple properties that doesn't need any special handling or formatting. |
+| Label                                          | Gets the value of the property                                                                    |
+| MediaPicker                                    | Represents a media picker item                                                                    |
+| MemberPicker                                   | Represents a member picker                                                                        |
+| MultiUrlPicker                                 | Represents a multi url picker                                                                     |
+| NestedContent                                  | Represents nested content                                                                         |
+| RichText                                       | Represents a rich text editor                                                                     |
+| UnsupportedProperty                            | Represents an unsupported property value                                                          |

--- a/docs/src/content/docs/v12/start.md
+++ b/docs/src/content/docs/v12/start.md
@@ -1,0 +1,72 @@
+---
+title: Nikcio.UHeadless Documentation - Version 12.0.0+
+description: Welcome to version 12 of the Nikcio.UHeadless documentation! This documentation aims to provide you with comprehensive resources to help you get started and make the most out of the Nikcio.UHeadless package.
+---
+
+Welcome to the documentation for Nikcio.UHeadless version 12.0.0! This documentation aims to provide you with comprehensive resources to help you get started and make the most out of the Nikcio.UHeadless package. Whether you're new to the package or looking to extend its functionality, we've got you covered.
+
+## Fundamentals
+
+In this section, you will find essential information about Nikcio.UHeadless and its core concepts. It covers topics such as extending Nikcio.UHeadless and important security considerations.
+
+### Getting Started
+- [Getting started](../fundamentals/getting-started): Find step-by-step instructions on how to install Nikcio.UHeadless and get started with querying content, media, and members.
+  - [Querying content](../fundamentals/querying/content): Explore the query options for content.
+  - [Querying media](../fundamentals/querying/media): Explore the query options for media.
+  - [Querying members](../fundamentals/querying/members): Explore the query options for members.
+  - [Querying properties](../fundamentals/querying/content): Discover how to query properties on content, media and members.
+- [Security Considerations](../fundamentals/security): Explore important security considerations when using Nikcio.UHeadless.
+
+## Extending Nikcio.UHeadless
+
+This section focuses on extending Nikcio.UHeadless to tailor it to your project's needs. It covers different areas where you can extend Nikcio.UHeadless, including content, media, members, integrations, and properties.
+
+### Content
+
+- [Extending Content](../extending/content): Learn how to extend the existing content model and how build your own in Nikcio.UHeadless.
+
+### Media
+
+- [Extending Media](../extending/media): Discover how to extend the existing media model and how build your own in Nikcio.UHeadless.
+
+### Members
+
+- [Extending Members](../extending/member): Learn how to extend the existing member model and how build your own in Nikcio.UHeadless.
+
+### Integrations
+
+- [Skybrud Redirects](../extending/skybrud-redirects): Explore how to integrate Nikcio.UHeadless with [Skybrud Redirects](https://marketplace.umbraco.com/package/skybrud.umbraco.redirects) for enhanced functionality.
+- [Url Tracker](../extending/url-tracker): Learn how to integrate Nikcio.UHeadless with [Url Tracker](https://marketplace.umbraco.com/package/urltracker) for enhanced functionality.
+
+### Performance
+
+- Persisted queries: Learn how to use persisted queries to improve performance when querying content, media, and members in Nikcio.UHeadless.
+  - HotChocolate has a great overview of how to integrate persisted queries in their [documentation](https://chillicream.com/docs/hotchocolate/performance#persisted-queries). Use add any extension methods to the `IRequestExecutorBuilder` in the `Program.cs` file where you configure UHeadless.
+
+### Properties
+
+- [Overview of Properties](../extending/properties/overview): Get an overview of the different property types and their usage in Nikcio.UHeadless.
+- [Block List](../extending/properties/block-list): Discover how to extend the block list property model in Nikcio.UHeadless.
+- [Custom Editor](../extending/properties/custom-editor): Learn how to use custom property editors in Nikcio.UHeadless.
+- [Media Picker](../extending/properties/media-picker): Explore how to extend the media picker property model in Nikcio.UHeadless.
+- [Rich Text](../extending/properties/rich-text): Learn how to extend the rich text property model in Nikcio.UHeadless.
+
+## Reference
+
+In the reference section, you will find detailed information about various aspects of Nikcio.UHeadless, including options, content, media, members, and properties.
+
+- [Options](../reference/options): Learn about the options available for configuring Nikcio.UHeadless.
+- [Endpoint Options](../reference/endpoint-options): Explore the available options for configuring the Nikcio.UHeadless endpoint.
+
+- [Content Reference](../reference/content): Find reference documentation for working with content in Nikcio.UHeadless.
+- [Media Reference](../reference/media): Find reference documentation for working with media in Nikcio.UHeadless.
+- [Members Reference](../reference/members): Find reference documentation for working with members in Nikcio.UHeadless.
+- [Properties Reference](../reference/properties): Find reference documentation for working with properties in Nikcio.UHeadless.
+
+We hope this documentation helps you make the most out of Nikcio.UHeadless. If you have any questions or need further assistance, don't hesitate to reach out to us.
+
+**Enjoy building a headless GraphQL interface with Nikcio.UHeadless!**
+
+---
+
+For those interested in supporting the development of Nikcio.UHeadless, consider becoming a sponsor on [GitHub Sponsors](https://github.com/sponsors/nikcio/). Your sponsorship helps us continue to improve and maintain this package. Thank you for your support!


### PR DESCRIPTION
## Summary

Adds documentation for the newly released v12.0.0 and updates the README compatibility tables.

### Changes
- **New  folder**: Copied from v11 docs with the following updates:
  - : Updated version references from 11.0.0 → 12.0.0
  -  & : Updated HotChocolate documentation links from `v13` → `v16` (matching the HotChocolate 16.x upgrade in v12.0.0)
- ****: Promoted v12 to the current sidebar (Welcome, Fundamentals, Extending, Reference); moved v11 into the "Older versions" collapsible section
- ****: Added a "Version 12.0.0+" entry linking to the new v12 docs
- ****: Updated both compatibility tables — Umbraco 18 now shows `v11.x.x & v12.x.x`

### Notes
- The CHANGELOG.md was already updated by Release Please with the 12.0.0 entry, so no changes were needed there.
- Follows the same pattern used when v11 was released (commit 889a01d0).