### PR TITLE
fix(ci): remove duplicate scope from dependabot commit messages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,6 @@ updates:
     open-pull-requests-limit: 10
     commit-message:
       prefix: "chore(deps-nuget)"
-      include: "scope"
     ignore:
       - dependency-name: "Umbraco.Cms.Web.Common"
       - dependency-name: "Umbraco.Cms.Web.Website"
@@ -44,7 +43,6 @@ updates:
     open-pull-requests-limit: 10
     commit-message:
       prefix: "chore(deps)"
-      include: "scope"
     groups:
       biome:
         patterns:
@@ -64,7 +62,6 @@ updates:
     open-pull-requests-limit: 10
     commit-message:
       prefix: "chore(deps-docs)"
-      include: "scope"
     groups:
       astro:
         patterns:
@@ -82,7 +79,6 @@ updates:
     open-pull-requests-limit: 10
     commit-message:
       prefix: "chore(deps-ci)"
-      include: "scope"
     groups:
       actions:
         patterns:


### PR DESCRIPTION
## Summary
- Removes `include: "scope"` from all four Dependabot update blocks in `.github/dependabot.yml`
- The prefixes already embed a scope (`chore(deps)`, `chore(deps-nuget)`, `chore(deps-docs)`, `chore(deps-ci)`), so `include: "scope"` made Dependabot append its own scope, producing invalid double-scope Conventional Commits

## Before
- `chore(deps)(deps): Bump next from 16.3.1 to 16.3.2`
- `chore(deps)(deps-dev): Bump @types/react-dom from 19.2.4 to 19.2.5`
- `chore(deps-ci)(deps): bump the actions group with 2 updates`

## After
- `chore(deps): Bump next from 16.3.1 to 16.3.2`
- `chore(deps-nuget): Bump Microsoft.VisualStudio.Threading.Analyzers from 17.14.15 to 18.7.23`